### PR TITLE
Add correct autocomplete value to city field

### DIFF
--- a/skins/laika/src/components/shared/Postal.vue
+++ b/skins/laika/src/components/shared/Postal.vue
@@ -36,6 +36,7 @@
 					id="city"
 					:placeholder="$t( 'form_for_example', { example: $t( 'donation_form_city_placeholder' ) } )"
 					v-model="formData.city.value"
+					autocomplete="address-level2"
 					@blur="$emit('field-changed', 'city')">
 			</b-input>
 		</b-field>


### PR DESCRIPTION
Previously the autocomplete attribute just had `on`, which prevented
proper autocompletion.

`address-level1` is probably the correct value for cities in Germany,
but pending https://stackoverflow.com/q/65395168/130121 .