### PR TITLE
Revert "Remove dependabot configuration"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# See the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "composer" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "wmde/funtech-core"
+


### PR DESCRIPTION
New that we moved back to GitHub, we want to use the automated updates
of Dependabot again.

This reverts commit b44937da83c4622871a7d0320ca66a7946af36c5, minus the
npm configuration, which is no longer needed as this repo is now
strictly for PHP code.
