### PR TITLE
Make error page independent from bucket selection

### DIFF
--- a/src/Presentation/Presenters/ErrorPageHtmlPresenter.php
+++ b/src/Presentation/Presenters/ErrorPageHtmlPresenter.php
@@ -13,7 +13,7 @@ use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
  */
 class ErrorPageHtmlPresenter {
 
-	private $template;
+	private TwigTemplate $template;
 
 	public function __construct( TwigTemplate $template ) {
 		$this->template = $template;


### PR DESCRIPTION
This change makes the internal error template independent from the
bucket selection by constructing the Twig template without using
getLayoutTemplate, which needs a selected A/B testing bucket.

This change is for situations where the error handler fires before the
bucket selection handler (e.g. because a hacker sent a malformed request
that throws an error in the Symfony HTTP layer), leading to a
non-recoverable "crash" (blank page) of the application.

Explain difference between ErrorPageHtmlPresenter and
ExceptionHtmlPresenterInterface in the doc comments of FunFunFactory.
