### PR TITLE
Change exception types in ValidateFeeController

### DIFF
--- a/app/Controllers/Validation/ValidateFeeController.php
+++ b/app/Controllers/Validation/ValidateFeeController.php
@@ -4,10 +4,10 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\App\Controllers\Validation;
 
-use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use UnexpectedValueException;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateFeeRequest;
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateFeeResult;
@@ -25,7 +25,7 @@ class ValidateFeeController {
 		try {
 			$fee = $this->euroFromRequest( $httpRequest );
 		}
-		catch ( InvalidArgumentException $ex ) {
+		catch ( UnexpectedValueException $ex ) {
 			return $this->newJsonErrorResponse( 'not-money' );
 		}
 
@@ -46,7 +46,7 @@ class ValidateFeeController {
 	private function euroFromRequest( Request $httpRequest ): Euro {
 		$currentFeeString = $httpRequest->request->get( 'membershipFee', '' );
 		if ( !ctype_digit( $currentFeeString ) ) {
-			throw new InvalidArgumentException();
+			throw new UnexpectedValueException();
 		}
 		return Euro::newFromCents(
 			intval( $currentFeeString )
@@ -55,7 +55,7 @@ class ValidateFeeController {
 
 	private function newJsonErrorResponse( string $errorCode ): Response {
 		if ( empty( self::ERROR_RESPONSE_MAP[$errorCode] ) ) {
-			throw new \OutOfBoundsException( 'Validation error code not found' );
+			throw new \OutOfRangeException( 'Validation error code not found' );
 		}
 		return new JsonResponse( [
 			'status' => 'ERR',


### PR DESCRIPTION
Exceptions should be either derived from LogicException (indicating
usage errors to the developers that would produce nonsensical results.
They should be caught by tests in CI) or RuntimeException (an unexpected
value enters the system, either through external services or user
input).

ValidateFeeController had used the wrong subclasses.

This was detected while investigating an errors log message related to
memberships.
