### PR TITLE
Remove old messages.json, add mail.json

### DIFF
--- a/app/MailTemplates.php
+++ b/app/MailTemplates.php
@@ -62,6 +62,7 @@ class MailTemplates {
 						'id' => 42,
 						'amount' => 12.34,
 						'needsModeration' => false,
+						'receiptOptIn' => false,
 					],
 					'recipient' => [
 						'lastName' => '姜',
@@ -155,6 +156,7 @@ class MailTemplates {
 					'salutation' => 'Herr',
 					'title' => 'Dr.',
 					'membershipFee' => 15.23,
+					'incentives' => [ 'totebag' ],
 				],
 				'variants' => [
 					'direct_debit_active_yearly' => [

--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -96,19 +96,6 @@
 		"siteId": 5,
 		"siteUrlBase": ""
 	},
-	"translation": {
-		"message-dir": "/messages",
-		"files": {
-			"messages": "messages.json",
-			"paymentTypes": "paymentTypes.json",
-			"paymentIntervals": "paymentIntervals.json",
-			"paymentStatus": "paymentStatus.json",
-			"validations": "validations.json",
-			"pageTitles": "pageTitles.json",
-			"membershipTypes": "membershipTypes.json",
-			"daysOfTheWeek": "daysOfTheWeek.json"
-		}
-	},
 	"payment-types": {
 		"BEZ": {
 			"donation-enabled": true,

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -661,28 +661,6 @@
         "siteUrlBase"
       ]
     },
-    "translation": {
-      "type": "object",
-      "Title": "Location of translations files",
-      "properties": {
-        "message-dir": {
-          "type": "string",
-          "title": "Folder where the translation files are stored",
-          "description": "Is relative to i18n-base-path",
-          "minLength": 1
-        },
-        "files": {
-          "type": "object",
-          "title": "Domain-Filename map of translation files",
-          "minProperties": 1
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "message-dir",
-        "files"
-      ]
-    },
     "payment-types": {
       "type": "object",
       "title": "Known payment types and their configuration",
@@ -847,7 +825,6 @@
     "sofort",
     "campaigns",
     "piwik",
-    "translation",
     "payment-types",
     "cookie",
     "preset-amounts",

--- a/build/app/config.dev.json
+++ b/build/app/config.dev.json
@@ -80,18 +80,6 @@
     "cancel-url": "http://localhost:8082/",
     "notification-url": "https://test-spenden-2.wikimedia.de/sofort-payment-notification"
   },
-  "translation": {
-    "message-dir": "/messages",
-    "files": {
-      "membershipTypes": "membershipTypes.json",
-      "messages": "messages.json",
-      "pageTitles": "pageTitles.json",
-      "paymentStatus": "paymentStatus.json",
-      "paymentTypes": "paymentTypes.json",
-      "validations": "validations.json",
-      "daysOfTheWeek": "daysOfTheWeek.json"
-    }
-  },
   "payment-types": {
     "BEZ": {
       "donation-enabled": true,

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1754,15 +1754,6 @@ class FunFunFactory implements LoggerAwareInterface {
 		throw new \InvalidArgumentException( 'Unsupported skin for use of funds:' . $this->config['skin'] );
 	}
 
-	/**
-	 * TranslationCollector is currently only used by the Laika Vue-based frontend
-	 * In the future, the desired solution would be to use laika_messages.json exclusively
-	 * for front-end related strings and any backend strings would be separated into individual files
-	 * to avoid unnecessary strings being loaded on the client side
-	 * @see https://phabricator.wikimedia.org/T225105
-	 *
-	 * @return TranslationsCollector
-	 */
 	public function getTranslationCollector(): TranslationsCollector {
 		return $this->createSharedObject( TranslationsCollector::class, function (): TranslationsCollector {
 			$translationsCollector = new TranslationsCollector( new SimpleFileFetcher() );
@@ -1874,9 +1865,8 @@ class FunFunFactory implements LoggerAwareInterface {
 	private function getMailTranslator(): TranslatorInterface {
 		return $this->createSharedObject( TranslatorInterface::class . '::MailTranslator', function (): TranslatorInterface {
 			$translator = new JsonTranslator( new SimpleFileFetcher() );
-			// TODO use mail.json (only with used keys) instead of messages.json when the translation handling has been deployed to prod
 			return $translator
-				->addFile( $this->getI18nDirectory() . '/messages/messages.json' )
+				->addFile( $this->getI18nDirectory() . '/messages/mail.json' )
 				->addFile( $this->getI18nDirectory() . '/messages/paymentTypes.json' )
 				->addFile( $this->getI18nDirectory() . '/messages/membershipTypes.json' );
 		} );

--- a/src/Infrastructure/ConfigReader.php
+++ b/src/Infrastructure/ConfigReader.php
@@ -80,9 +80,6 @@ class ConfigReader {
 		if ( empty( $config['twig']['loaders']['array'] ) ) {
 			$config['twig']['loaders']['array'] = new stdClass();
 		}
-		if ( empty( $config['translation']['files'] ) ) {
-			$config['translation']['files'] = new stdClass();
-		}
 		return json_decode( json_encode( $config ), false );
 	}
 

--- a/tests/Unit/Infrastructure/Translation/JsonTranslatorTest.php
+++ b/tests/Unit/Infrastructure/Translation/JsonTranslatorTest.php
@@ -15,7 +15,7 @@ class JsonTranslatorTest extends TestCase {
 
 	public function testGivenATranslationKey_translatorLooksUpTranslation(): void {
 		$translator = new JsonTranslator( $this->newTranslationSource() );
-		$translator->addFile( 'messages.json' );
+		$translator->addFile( 'testytest_messages.json' );
 
 		$translatedText = $translator->trans( 'donate_now' );
 
@@ -24,7 +24,7 @@ class JsonTranslatorTest extends TestCase {
 
 	public function testGivenATranslationKeyWithParams_translatorReplacesPlaceholders(): void {
 		$translator = new JsonTranslator( $this->newTranslationSource() );
-		$translator->addFile( 'messages.json' );
+		$translator->addFile( 'testytest_messages.json' );
 
 		$translatedText = $translator->trans( 'you_will_pay', [
 			'%amount%' => '5 %currency%',
@@ -37,7 +37,7 @@ class JsonTranslatorTest extends TestCase {
 
 	public function testGivenAnUnkownTranslationKey_translatorThrowsAnException(): void {
 		$translator = new JsonTranslator( $this->newTranslationSource() );
-		$translator->addFile( 'messages.json' );
+		$translator->addFile( 'testytest_messages.json' );
 
 		$this->expectException( \InvalidArgumentException::class );
 
@@ -49,7 +49,7 @@ class JsonTranslatorTest extends TestCase {
 	private function newTranslationSource(): InMemoryFileFetcher {
 		$source = new InMemoryFileFetcher(
 			[
-				'messages.json' => json_encode(
+				'testytest_messages.json' => json_encode(
 					[
 						'donate_now' => 'Jetzt spenden',
 						'you_will_pay' => 'Sie spenden %amount% %interval%'


### PR DESCRIPTION
- removes old translation schema from schema.json and its usages
- use new translations content file mail.json for mail related translation keys
- adjust naming in JsonTranslatorTest to be precise that it's just a test json object

is caring for the last 2 points on this todo list:
https://phabricator.wikimedia.org/T225105