### PR TITLE
Localise numbers in emails

### DIFF
--- a/app/mail_templates/Donation_Confirmation.txt.twig
+++ b/app/mail_templates/Donation_Confirmation.txt.twig
@@ -1,4 +1,4 @@
-{%- set formattedAmount = donation.amount|number_format(2, ',', '.') ~ ' Euro' -%}
+{%- set formattedAmount = donation.amount|format_number(locale=locale) ~ ' Euro' -%}
 {$ greeting_generator.createInformalLastnameGreeting( recipient.salutation, recipient.lastName, recipient.title )|raw $}
 
 {% if donation.needsModeration %}{# Moderated emails look completely different #}

--- a/app/mail_templates/Membership_Application_Confirmation.txt.twig
+++ b/app/mail_templates/Membership_Application_Confirmation.txt.twig
@@ -1,4 +1,4 @@
-{%- set formattedAmount = membershipFee|number_format(2, ',', '.') ~ ' Euro' -%}
+{%- set formattedAmount = membershipFee|format_number(locale=locale) ~ ' Euro' -%}
 
 {# TODO improve incentive handling  #}
 {% set incentiveText = ( incentives|length > 0 ) ? 'mit dem Wikipedia-Stoffbeutel ' : '' %}

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
 		"ext-sodium": "*",
 
 		"twig/twig": "^3.0",
+		"twig/intl-extra": "^3.3",
 
 		"wmde/email-address": "~1.0",
 		"wmde/euro": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9cde1b28488c2d8b70cfba3e2121a40e",
+    "content-hash": "cdab216ba7ec74880bb2d6795091e0bb",
     "packages": [
         {
             "name": "airbrake/phpbrake",
@@ -4651,6 +4651,94 @@
             "time": "2021-06-30T08:27:49+00:00"
         },
         {
+            "name": "symfony/intl",
+            "version": "v5.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/intl.git",
+                "reference": "92a24a5fd1087511d29a5c7dd98d97c9e2208e75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/92a24a5fd1087511d29a5c7dd98d97c9e2208e75",
+                "reference": "92a24a5fd1087511d29a5c7dd98d97c9e2208e75",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^4.4|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Intl\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ],
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Eriksen Costa",
+                    "email": "eriksen.costa@infranology.com.br"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a PHP replacement layer for the C intl extension that includes additional data from the ICU library",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "i18n",
+                "icu",
+                "internationalization",
+                "intl",
+                "l10n",
+                "localization"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/intl/tree/v5.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T12:28:50+00:00"
+        },
+        {
             "name": "symfony/monolog-bridge",
             "version": "v5.3.3",
             "source": {
@@ -6650,6 +6738,75 @@
                 }
             ],
             "time": "2021-06-24T08:13:00+00:00"
+        },
+        {
+            "name": "twig/intl-extra",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/intl-extra.git",
+                "reference": "919e8f945c30bd3efeb6a4d79722cda538116658"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/intl-extra/zipball/919e8f945c30bd3efeb6a4d79722cda538116658",
+                "reference": "919e8f945c30bd3efeb6a4d79722cda538116658",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/intl": "^4.3|^5.0",
+                "twig/twig": "^2.4|^3.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4.9|^5.0.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Twig\\Extra\\Intl\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "A Twig extension for Intl",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "intl",
+                "twig"
+            ],
+            "support": {
+                "source": "https://github.com/twigphp/intl-extra/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-01T14:58:18+00:00"
         },
         {
             "name": "twig/twig",

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\EntityManager;
 use FileFetcher\ErrorLoggingFileFetcher;
 use FileFetcher\SimpleFileFetcher;
 use GuzzleHttp\Client;
+use Locale;
 use NumberFormatter;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
@@ -472,8 +473,10 @@ class FunFunFactory implements LoggerAwareInterface {
 				$this->getContentProvider(),
 				$this->getUrlGenerator(),
 			);
+			$locale = Locale::parseLocale( $this->getLocale() );
 			return $factory->newTemplatingEnvironment(
-				$this->getDayOfWeekName()
+				$this->getDayOfWeekName(),
+				$locale['language']
 			);
 		} );
 	}

--- a/src/Factories/MailerTemplatingFactory.php
+++ b/src/Factories/MailerTemplatingFactory.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\Factories;
 
 use Twig\Environment;
+use Twig\Extra\Intl\IntlExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 use WMDE\Fundraising\ContentProvider\ContentProvider;
@@ -24,9 +25,10 @@ class MailerTemplatingFactory extends TwigFactory {
 		$this->urlGenerator = $urlGenerator;
 	}
 
-	public function newTemplatingEnvironment( string $dayOfWeek ): Environment {
+	public function newTemplatingEnvironment( string $dayOfWeek, string $locale ): Environment {
 		$globals = [
-			'day_of_the_week' => $dayOfWeek
+			'day_of_the_week' => $dayOfWeek,
+			'locale' => $locale,
 		];
 
 		return $this->newTwigEnvironment( $globals );
@@ -71,6 +73,12 @@ class MailerTemplatingFactory extends TwigFactory {
 					return $this->urlGenerator->generateAbsoluteUrl( $name, $parameters );
 				}
 			)
+		];
+	}
+
+	protected function getExtensions(): array {
+		return [
+			new IntlExtension()
 		];
 	}
 


### PR DESCRIPTION
This adds Symfony and Twig intl classes to allow locale based currency formatting in mail

Ticket: https://phabricator.wikimedia.org/T284918