### PR TITLE
Avoid empty bucket logs

### DIFF
--- a/src/BucketTesting/Domain/Model/BucketLog.php
+++ b/src/BucketTesting/Domain/Model/BucketLog.php
@@ -52,4 +52,9 @@ class BucketLog {
 	public function addBucket( string $bucketName, string $campaign ) {
 		$this->buckets->add( new BucketLogBucket( $this, $bucketName, $campaign ) );
 	}
+
+	public function shouldBeLogged(): bool {
+		return $this->getBuckets()->count() > 0;
+	}
+
 }

--- a/src/BucketTesting/Logging/DatabaseBucketLogger.php
+++ b/src/BucketTesting/Logging/DatabaseBucketLogger.php
@@ -25,6 +25,9 @@ class DatabaseBucketLogger implements BucketLogger {
 
 		$bucketLog = new BucketLog( $metadata['id'], $event->getName() );
 		$this->addBucketLogBuckets( $bucketLog, ...$buckets );
+		if ( !$bucketLog->shouldBeLogged() ) {
+			return;
+		}
 
 		$this->bucketLoggingRepository->storeBucketLog( $bucketLog );
 	}


### PR DESCRIPTION
When a potential bucket log entry has no buckets, don't log it to the
database, avoiding 1:n entries for bucket_log:bucket_log_buckets with no
buckets (which doesn't make sense from a domain perspective).

This is a followup for #2288
This is for https://phabricator.wikimedia.org/T262542
