### PR TITLE
Activate passive fingerprinting

### DIFF
--- a/skins/laika/templates/matomo.html.twig
+++ b/skins/laika/templates/matomo.html.twig
@@ -1,7 +1,6 @@
 <!-- Matomo -->
 <script>
 	var _paq = _paq || [];
-	_paq.push(['requireConsent']);
 	_paq.push(['requireCookieConsent']);
 	{% if initialFormValues.paymentType != '' %}
 		_paq.push( [ 'setCustomDimension', 1, '{$ initialFormValues.paymentType $}' ] );


### PR DESCRIPTION
This removes the global consent requirements from the
matomo template and activates passive fingerprinting.

Ticket: https://phabricator.wikimedia.org/T290560
Related: https://gitlab.com/fun-tech/fundraising-app-frontend/-/merge_requests/111