### PR TITLE
Add matomo goal ids to config

### DIFF
--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -93,6 +93,8 @@
 	"piwik": {
 		"baseUrl": "//tracking.wikimedia.de/",
 		"siteId": 5,
+		"donationConfirmationGoalId": 1,
+		"membershipApplicationConfirmationGoalId": 2,
 		"siteUrlBase": ""
 	},
 	"payment-types": {

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -66,6 +66,8 @@
 	"piwik": {
 		"baseUrl": "//tracking.wikimedia.de/",
 		"siteId": 1234,
+		"donationConfirmationGoalId": 1,
+		"membershipApplicationConfirmationGoalId": 2,
 		"siteUrlBase": "http://test-spenden.wikimedia.local"
 	},
 	"purging-secret": "Not so secret, testing",

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -626,20 +626,32 @@
       "type": "object",
       "title": "Piwik settings",
       "properties": {
-          "baseUrl": {
-            "type": "string",
-            "title": "Tracker URL",
-            "description": "Base URL for the Piwik installation. Make sure it starts with //, not with http:// or https://, that way the browser will automatically select the right transport when the URL is printed in a template",
-            "format": "url",
-            "default": "//tracking.wikimedia.de/",
-            "pattern": "^(\\/){2}[a-zA-Z0-9.\\/]+$"
-          },
-          "siteId": {
-            "type": "integer",
-            "title": "Site ID",
-            "description": "Unique site id (configured in Piwik)",
-            "default": 1
-          },
+        "baseUrl": {
+          "type": "string",
+          "title": "Tracker URL",
+          "description": "Base URL for the Piwik installation. Make sure it starts with //, not with http:// or https://, that way the browser will automatically select the right transport when the URL is printed in a template",
+          "format": "url",
+          "default": "//tracking.wikimedia.de/",
+          "pattern": "^(\\/){2}[a-zA-Z0-9.\\/]+$"
+        },
+        "siteId": {
+          "type": "integer",
+          "title": "Site ID",
+          "description": "Unique site id (configured in Piwik)",
+          "default": 1
+        },
+        "donationConfirmationGoalId": {
+          "type": "integer",
+          "title": "Donation Confirmation Goal ID",
+          "description": "Unique id (configured in Piwik)",
+          "default": 1
+        },
+        "membershipApplicationConfirmationGoalId": {
+          "type": "integer",
+          "title": "Membership Application Confirmation Goal ID",
+          "description": "Unique id (configured in Piwik)",
+          "default": 2
+        },
         "siteUrlBase": {
           "type": "string",
           "title": "Site url",
@@ -652,6 +664,8 @@
       "required": [
         "baseUrl",
         "siteId",
+        "donationConfirmationGoalId",
+        "membershipApplicationConfirmationGoalId",
         "siteUrlBase"
       ]
     },


### PR DESCRIPTION
We use different site and goal ids in test
and production so this adds them to the
environment configuration.

Ticket: https://phabricator.wikimedia.org/T290561