### PR TITLE
Fix IBAN validation result

### DIFF
--- a/doc/Planning_for_Payment_refactoring.md
+++ b/doc/Planning_for_Payment_refactoring.md
@@ -75,4 +75,10 @@ Construct minimal payment method data from request (only bank data has real data
 
 **Suggestion:** Create an `AddPayment` use case in Payment domain, that constructs the PaymentMethod (and saves it if needed).
 
+### Iban should be a valid domain object
+The `Iban` class should not allow for malformed IBANs (not starting with 2 letters, shorter than 12 chars) to perform its duties.
+It should throw `UnexpectedValueException` when it encounters an invalid string. 
+Code using the domain object should pre-check for malformed IBANs and validate accordingly (avoiding the `UnexpectedValueException`).
+The `IbanValidator` (and its kontocheck implementation) should validate the *Domain* validity of the IBAN object (i.e. country prefix, bank or account does not exist).
 
+ 

--- a/src/Infrastructure/Payment/KontoCheckIbanValidator.php
+++ b/src/Infrastructure/Payment/KontoCheckIbanValidator.php
@@ -27,7 +27,7 @@ class KontoCheckIbanValidator implements IbanValidator {
 
 	public function validate( Iban $value, string $fieldName = '' ): ValidationResult {
 		if ( iban_check( $value->toString() ) <= 0 ) {
-			return new ValidationResult( new ConstraintViolation( $value, 'iban_invalid', $fieldName ) );
+			return new ValidationResult( new ConstraintViolation( $value->toString(), 'iban_invalid', $fieldName ) );
 		}
 
 		return new ValidationResult();

--- a/tests/Unit/Infrastructure/Payment/KontoCheckIbanValidatorTest.php
+++ b/tests/Unit/Infrastructure/Payment/KontoCheckIbanValidatorTest.php
@@ -80,4 +80,17 @@ class KontoCheckIbanValidatorTest extends TestCase {
 		$validator = $this->newValidator();
 		$this->assertFalse( $validator->validate( new Iban( $iban ) )->isSuccessful() );
 	}
+
+	/**
+	 * @dataProvider notWellFormedIbanProvider
+	 */
+	public function testGivenNotWellFormedIban_validationResultIsOneViolationWithStringifiedIban( string $malformedIban ): void {
+		$validator = $this->newValidator();
+		$iban = new Iban( $malformedIban );
+
+		$violations = $validator->validate( $iban )->getViolations();
+
+		$this->assertCount( 1, $violations );
+		$this->assertSame( $iban->toString(), $violations[0]->getValue() );
+	}
 }


### PR DESCRIPTION
IBAN constraint violations contained an `Iban` instance instead of a
string, which `printf` could not render when processing the constraint
violations.

This is for https://phabricator.wikimedia.org/T295479
