### PR TITLE
Add configuration for C21_WMDE_Test_12

### DIFF
--- a/app/EventHandlers/StoreBucketSelection.php
+++ b/app/EventHandlers/StoreBucketSelection.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\App\EventHandlers;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -38,8 +39,21 @@ class StoreBucketSelection implements EventSubscriberInterface {
 
 		$request->attributes->set(
 			self::SHOULD_STORE_BUCKET_COOKIE,
-			$request->cookies->get( CookieNames::CONSENT ) === 'yes'
+			$this->shouldStoreCookie( $request )
 		);
+	}
+
+	/**
+	 * TODO: Remove this after C21_WMDE_Test_12
+	 *
+	 * @param Request $request
+	 * @return bool
+	 */
+	private function shouldStoreCookie( Request $request ): bool {
+		if ( $this->factory->forceChoiceCookieStorage() ) {
+			return true;
+		}
+		return $request->cookies->get( CookieNames::CONSENT ) === 'yes';
 	}
 
 	public function storeSelectedBuckets( ResponseEvent $event ): void {

--- a/app/config/campaigns.dev.yml
+++ b/app/config/campaigns.dev.yml
@@ -19,3 +19,8 @@ campaigns:
     active: true
     start: "2021-09-01"
     default_bucket: "direct"
+
+  optional_cookie_notice:
+    active: true
+    start: "2021-01-01"
+    default_bucket: "show"

--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -74,3 +74,16 @@ campaigns:
       url_key: ast
       active: true
       param_only: true
+
+    optional_cookie_notice:
+      description: Test what effect the cookie notice has on donations
+      reference: "https://phabricator.wikimedia.org/T295869"
+      start: "2021-11-18"
+      end: "2021-12-31"
+      buckets:
+        - "show"
+        - "hide"
+      default_bucket: "show"
+      url_key: ocn
+      active: true
+      param_only: true

--- a/src/Factories/ChoiceFactory.php
+++ b/src/Factories/ChoiceFactory.php
@@ -27,4 +27,16 @@ class ChoiceFactory {
 		}
 		throw new UnknownChoiceDefinition( 'Address type configuration failure.' );
 	}
+
+	/**
+	 * TODO: Remove this after C21_WMDE_Test_12
+	 *
+	 * @return bool
+	 */
+	public function forceChoiceCookieStorage(): bool {
+		if ( $this->featureToggle->featureIsActive( 'campaigns.optional_cookie_notice.hide' ) ) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1665,6 +1665,15 @@ class FunFunFactory implements LoggerAwareInterface {
 		return $this->getChoiceFactory()->getAddressType();
 	}
 
+	/**
+	 * TODO: Remove this after C21_WMDE_Test_12
+	 *
+	 * @return bool
+	 */
+	public function forceChoiceCookieStorage(): bool {
+		return $this->getChoiceFactory()->forceChoiceCookieStorage();
+	}
+
 	public function getBucketSelector(): BucketSelector {
 		return $this->createSharedObject( BucketSelector::class, function (): BucketSelector {
 			return new BucketSelector( $this->getCampaignCollection(), new RandomBucketSelection() );


### PR DESCRIPTION
This test hides the cookie banner for
some users. In order to do this we need
to force the storage of the AB test
cookies for them.

Ticket: https://phabricator.wikimedia.org/T295869