### PR TITLE
Remove /status route

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -205,11 +205,6 @@ legacy_route_posts.php:
     controller: 'WMDE\Fundraising\Frontend\App\Controllers\PageNotFoundController::index'
     requirements: { wildcard: .* }
 
-status:
-    path: /status
-    methods: [GET]
-    controller: null
-
 api_cities.json:
     path: /api/v1/cities.json
     methods: [POST]


### PR DESCRIPTION
The route was used for monitoring, but is no longer needed on the new
infrastructure, where we do regular requests to the main donation page.

It has been defunct anyway since the move to Symfony.
