### PR TITLE
Fix PHPStan errors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,6 +16,6 @@ parameters:
 			path: src/BucketTesting/Validation/FeatureToggleParser.php
 
 		-
-			message: "#^Parameter \\#1 \\$level of static method Monolog\\\\Logger\\:\\:toMonologLevel\\(\\) expects 100\\|200\\|250\\|300\\|400\\|500\\|550\\|600\\|non\\-empty\\-string, string given\\.$#"
+			message: "#^Parameter \\#1 \\$level of static method Monolog\\\\Logger\\:\\:toMonologLevel\\(\\) expects 100\\|200\\|250\\|300\\|400\\|500\\|550\\|600\\|'ALERT'\\|'alert'\\|'CRITICAL'\\|'critical'\\|'DEBUG'\\|'debug'\\|'EMERGENCY'\\|'emergency'\\|'ERROR'\\|'error'\\|'INFO'\\|'info'\\|'NOTICE'\\|'notice'\\|'WARNING'\\|'warning', string given\\.$#"
 			count: 1
 			path: src/Factories/ErrbitLoggerFactory.php

--- a/src/Autocomplete/Domain/Model/Location.php
+++ b/src/Autocomplete/Domain/Model/Location.php
@@ -10,6 +10,12 @@ namespace WMDE\Fundraising\Frontend\Autocomplete\Domain\Model;
  */
 class Location {
 
+	/**
+	 * ID automagically set by Doctrine ORM if needed
+	 *
+	 * @var int|null
+	 * @phpstan-ignore-next-line
+	 */
 	private ?int $id;
 	private string $stateName;
 	private string $stateNutscode;

--- a/src/BucketTesting/CampaignBuilder.php
+++ b/src/BucketTesting/CampaignBuilder.php
@@ -15,11 +15,9 @@ use WMDE\Fundraising\Frontend\BucketTesting\Domain\Model\CampaignDate;
 class CampaignBuilder {
 
 	private DateTimeZone $timezone;
-	private DateTimeZone $utc;
 
 	public function __construct( DateTimeZone $timezone ) {
 		$this->timezone = $timezone;
-		$this->utc = new DateTimeZone( 'UTC' );
 	}
 
 	public function getCampaigns( array $campaignConfig ): array {

--- a/src/BucketTesting/Domain/Model/BucketLog.php
+++ b/src/BucketTesting/Domain/Model/BucketLog.php
@@ -11,6 +11,12 @@ use Doctrine\Common\Collections\Collection;
 
 class BucketLog {
 
+	/**
+	 * ID automagically set by Doctrine ORM
+	 *
+	 * @var int
+	 * @phpstan-ignore-next-line
+	 */
 	private int $id;
 	private int $externalId;
 	private string $eventName;

--- a/src/BucketTesting/Domain/Model/BucketLogBucket.php
+++ b/src/BucketTesting/Domain/Model/BucketLogBucket.php
@@ -6,6 +6,12 @@ namespace WMDE\Fundraising\Frontend\BucketTesting\Domain\Model;
 
 class BucketLogBucket {
 
+	/**
+	 * ID automagically set by Doctrine ORM
+	 *
+	 * @var int
+	 * @phpstan-ignore-next-line
+	 */
 	private int $id;
 	private BucketLog $bucketLog;
 	private string $name;

--- a/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
@@ -7,7 +7,6 @@ namespace WMDE\Fundraising\Frontend\Presentation\Presenters;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donation;
 use WMDE\Fundraising\Frontend\Infrastructure\AddressType;
 use WMDE\Fundraising\Frontend\Infrastructure\UrlGenerator;
-use WMDE\Fundraising\Frontend\Presentation\DonationMembershipApplicationAdapter;
 use WMDE\Fundraising\Frontend\Presentation\DonorDataFormatter;
 use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
 
@@ -19,17 +18,13 @@ use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
 class DonationConfirmationHtmlPresenter {
 
 	private TwigTemplate $template;
-	private DonationMembershipApplicationAdapter $donationMembershipApplicationAdapter;
 	private UrlGenerator $urlGenerator;
-	private DonorDataFormatter $donorDataFormatter;
 	private array $countries;
 	private object $validation;
 
 	public function __construct( TwigTemplate $template, UrlGenerator $urlGenerator, array $countries, object $validation ) {
 		$this->template = $template;
 		$this->urlGenerator = $urlGenerator;
-		$this->donationMembershipApplicationAdapter = new DonationMembershipApplicationAdapter();
-		$this->donorDataFormatter = new DonorDataFormatter();
 		$this->countries = $countries;
 		$this->validation = $validation;
 	}
@@ -43,6 +38,7 @@ class DonationConfirmationHtmlPresenter {
 
 	private function getConfirmationPageArguments( Donation $donation, string $updateToken, string $accessToken,
 		array $urlEndpoints ): array {
+		$donorDataFormatter = new DonorDataFormatter();
 		return [
 			'donation' => [
 				'id' => $donation->getId(),
@@ -51,17 +47,17 @@ class DonationConfirmationHtmlPresenter {
 				'paymentType' => $donation->getPaymentMethodId(),
 				'optsIntoDonationReceipt' => $donation->getOptsIntoDonationReceipt(),
 				'optsIntoNewsletter' => $donation->getOptsIntoNewsletter(),
-				'bankTransferCode' => $this->donorDataFormatter->getBankTransferCode( $donation->getPaymentMethod() ),
-				'creationDate' => $this->donorDataFormatter->getDonationDate(),
-				'cookieDuration' => $this->donorDataFormatter->getHideBannerCookieDuration(),
+				'bankTransferCode' => $donorDataFormatter->getBankTransferCode( $donation->getPaymentMethod() ),
+				'creationDate' => $donorDataFormatter->getDonationDate(),
+				'cookieDuration' => $donorDataFormatter->getHideBannerCookieDuration(),
 				'updateToken' => $updateToken,
 				'accessToken' => $accessToken
 			],
 			'countries' => $this->countries,
 			'addressValidationPatterns' => $this->validation,
 			'addressType' => AddressType::donorToPresentationAddressType( $donation->getDonor() ),
-			'address' => $this->donorDataFormatter->getAddressArguments( $donation ),
-			'bankData' => $this->donorDataFormatter->getBankDataArguments( $donation->getPaymentMethod() ),
+			'address' => $donorDataFormatter->getAddressArguments( $donation ),
+			'bankData' => $donorDataFormatter->getBankDataArguments( $donation->getPaymentMethod() ),
 			'urls' => array_merge(
 				$urlEndpoints,
 				[

--- a/src/Presentation/Presenters/DonorUpdateHtmlPresenter.php
+++ b/src/Presentation/Presenters/DonorUpdateHtmlPresenter.php
@@ -7,7 +7,6 @@ namespace WMDE\Fundraising\Frontend\Presentation\Presenters;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donation;
 use WMDE\Fundraising\DonationContext\UseCases\UpdateDonor\UpdateDonorResponse;
 use WMDE\Fundraising\Frontend\Infrastructure\UrlGenerator;
-use WMDE\Fundraising\Frontend\Presentation\DonationMembershipApplicationAdapter;
 use WMDE\Fundraising\Frontend\Presentation\DonorDataFormatter;
 use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
 
@@ -18,16 +17,12 @@ use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
  */
 class DonorUpdateHtmlPresenter {
 
-	private $template;
-	private $donationMembershipApplicationAdapter;
-	private $urlGenerator;
-	private $donorDataFormatter;
+	private TwigTemplate $template;
+	private UrlGenerator $urlGenerator;
 
 	public function __construct( TwigTemplate $template, UrlGenerator $urlGenerator ) {
 		$this->template = $template;
 		$this->urlGenerator = $urlGenerator;
-		$this->donationMembershipApplicationAdapter = new DonationMembershipApplicationAdapter();
-		$this->donorDataFormatter = new DonorDataFormatter();
 	}
 
 	public function present( UpdateDonorResponse $updateDonorResponse, Donation $donation, string $updateToken, string $accessToken ): string {
@@ -46,6 +41,7 @@ class DonorUpdateHtmlPresenter {
 	}
 
 	private function getConfirmationPageArguments( Donation $donation, string $updateToken, string $accessToken ): array {
+		$donorDataFormatter = new DonorDataFormatter();
 		return [
 			'donation' => [
 				'id' => $donation->getId(),
@@ -54,16 +50,16 @@ class DonorUpdateHtmlPresenter {
 				'paymentType' => $donation->getPaymentMethodId(),
 				'optsIntoDonationReceipt' => $donation->getOptsIntoDonationReceipt(),
 				'optsIntoNewsletter' => $donation->getOptsIntoNewsletter(),
-				'bankTransferCode' => $this->donorDataFormatter->getBankTransferCode(
+				'bankTransferCode' => $donorDataFormatter->getBankTransferCode(
 					$donation->getPaymentMethod()
 				),
-				'creationDate' => $this->donorDataFormatter->getDonationDate(),
-				'cookieDuration' => $this->donorDataFormatter->getHideBannerCookieDuration(),
+				'creationDate' => $donorDataFormatter->getDonationDate(),
+				'cookieDuration' => $donorDataFormatter->getHideBannerCookieDuration(),
 				'updateToken' => $updateToken,
 				'accessToken' => $accessToken
 			],
-			'address' => $this->donorDataFormatter->getAddressArguments( $donation ),
-			'bankData' => $this->donorDataFormatter->getBankDataArguments( $donation->getPaymentMethod() ),
+			'address' => $donorDataFormatter->getAddressArguments( $donation ),
+			'bankData' => $donorDataFormatter->getBankDataArguments( $donation->getPaymentMethod() ),
 			'commentUrl' => $this->urlGenerator->generateRelativeUrl(
 				'AddCommentPage',
 				[

--- a/tests/EdgeToEdge/WebRouteTestCase.php
+++ b/tests/EdgeToEdge/WebRouteTestCase.php
@@ -136,7 +136,7 @@ abstract class WebRouteTestCase extends KernelTestCase {
 	protected static function bootKernel( array $options = [] ): KernelInterface {
 		$kernel = parent::bootKernel( $options );
 
-		static::modifyBootstrapperConfiguration();
+		self::modifyBootstrapperConfiguration();
 		$factory = static::getFactory();
 		static::rebuildDatabaseSchema( $factory );
 

--- a/tests/Unit/BucketTesting/InactiveCampaignBucketSelectionTest.php
+++ b/tests/Unit/BucketTesting/InactiveCampaignBucketSelectionTest.php
@@ -25,8 +25,8 @@ class InactiveCampaignBucketSelectionTest extends TestCase {
 		$campaign = new Campaign(
 			'test1',
 			't1',
-			( new CampaignDate() )->sub( new \DateInterval( 'P1M' ) ),
-			( new CampaignDate() )->add( new \DateInterval( 'P1M' ) ),
+			( $this->now )->sub( new \DateInterval( 'P1M' ) ),
+			( $this->now )->add( new \DateInterval( 'P1M' ) ),
 			Campaign::INACTIVE
 		);
 		$defaultBucket = new Bucket( 'bucket1', $campaign, Bucket::DEFAULT );
@@ -34,7 +34,7 @@ class InactiveCampaignBucketSelectionTest extends TestCase {
 			->addBucket( $defaultBucket )
 			->addBucket( new Bucket( 'bucket2', $campaign, Bucket::NON_DEFAULT ) );
 
-		$selectionStrategy = new InactiveCampaignBucketSelection( new CampaignDate() );
+		$selectionStrategy = new InactiveCampaignBucketSelection( $this->now );
 
 		$this->assertSame( $defaultBucket, $selectionStrategy->selectBucketForCampaign( $campaign ) );
 	}
@@ -43,8 +43,8 @@ class InactiveCampaignBucketSelectionTest extends TestCase {
 		$campaign = new Campaign(
 			'test1',
 			't1',
-			( new CampaignDate() )->sub( new \DateInterval( 'P2M' ) ),
-			( new CampaignDate() )->sub( new \DateInterval( 'P1M' ) ),
+			( $this->now )->sub( new \DateInterval( 'P2M' ) ),
+			( $this->now )->sub( new \DateInterval( 'P1M' ) ),
 			Campaign::ACTIVE
 		);
 		$defaultBucket = new Bucket( 'bucket1', $campaign, Bucket::DEFAULT );
@@ -52,7 +52,7 @@ class InactiveCampaignBucketSelectionTest extends TestCase {
 			->addBucket( $defaultBucket )
 			->addBucket( new Bucket( 'bucket2', $campaign, Bucket::NON_DEFAULT ) );
 
-		$selectionStrategy = new InactiveCampaignBucketSelection( new CampaignDate() );
+		$selectionStrategy = new InactiveCampaignBucketSelection( $this->now );
 
 		$this->assertSame( $defaultBucket, $selectionStrategy->selectBucketForCampaign( $campaign ) );
 	}
@@ -61,15 +61,15 @@ class InactiveCampaignBucketSelectionTest extends TestCase {
 		$campaign = new Campaign(
 			'test1',
 			't1',
-			( new CampaignDate() )->sub( new \DateInterval( 'P1M' ) ),
-			( new CampaignDate() )->add( new \DateInterval( 'P1M' ) ),
+			( $this->now )->sub( new \DateInterval( 'P1M' ) ),
+			( $this->now )->add( new \DateInterval( 'P1M' ) ),
 			Campaign::ACTIVE
 		);
 		$campaign
 			->addBucket( new Bucket( 'bucket1', $campaign, Bucket::DEFAULT ) )
 			->addBucket( new Bucket( 'bucket2', $campaign, Bucket::NON_DEFAULT ) );
 
-		$selectionStrategy = new InactiveCampaignBucketSelection( new CampaignDate() );
+		$selectionStrategy = new InactiveCampaignBucketSelection( $this->now );
 
 		$this->assertNull( $selectionStrategy->selectBucketForCampaign( $campaign ) );
 	}


### PR DESCRIPTION
The new PHPStan version found more errors. This commit fixes them:

Added comments for IDs autogenerated by Doctrine.
We should abandon bad practice when we tackle the DB refactoring
(https://phabricator.wikimedia.org/T203679)

Moved state into local variable in presenters. This makes the code
more readable and memory-efficient. This was not a PHPStan error but
bubbled up while reading the code.