### PR TITLE
Mount content resources in proxy container

### DIFF
--- a/build/proxy/nginx.conf.template
+++ b/build/proxy/nginx.conf.template
@@ -16,6 +16,11 @@ server {
             rewrite ^/piwik/(.*) https://tracking.wikimedia.de/$1 permanent;
         }
 
+		# fundraising-frontend-content, mounted into container from vendor
+		location /resources/ {
+			root /usr/share/nginx/www/fundraising-frontend-content;
+		}
+
         # deny access to dot files
         location ~ (^|/)\. {
                 return 403;

--- a/composer.lock
+++ b/composer.lock
@@ -10324,12 +10324,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-frontend-content",
-                "reference": "4f79f274ab630340242f1e98f6499f47cd25ac51"
+                "reference": "a4c4aa38fea4a70c1c149189a80f06e37734393a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/4f79f274ab630340242f1e98f6499f47cd25ac51",
-                "reference": "4f79f274ab630340242f1e98f6499f47cd25ac51",
+                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/a4c4aa38fea4a70c1c149189a80f06e37734393a",
+                "reference": "a4c4aa38fea4a70c1c149189a80f06e37734393a",
                 "shasum": ""
             },
             "require": {
@@ -10373,7 +10373,7 @@
                 "CC0-1.0"
             ],
             "description": "i18n for FundraisingFrontend",
-            "time": "2021-12-06T17:00:22+00:00"
+            "time": "2022-01-20T12:11:52+00:00"
         },
         {
             "name": "wmde/fundraising-phpcs",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ./build/proxy/nginx.conf.template:/etc/nginx/conf.d/nginx.conf.template:ro
       - ./build/proxy/includes:/etc/nginx/conf.d/includes:ro
       - ./web:/usr/share/nginx/www/spenden.wikimedia.de/current/web:ro
+      - ./vendor/wmde/fundraising-frontend-content:/usr/share/nginx/www/fundraising-frontend-content:ro
     environment:
       - NGINX_HOST=spenden.wikimedia.de
       - NGINX_PORT=8080


### PR DESCRIPTION
The NGinX reverse proxy now serves the `resources` directory from the
fundraising-frontend-content repository, bringing the dev environment
closer to the experience on the server.

Note, that the server does NOT use the fundraising-frontend-content as a
composer dev dependency but via a separate installation process with a
deployment system (drone.io at the time of this commit.)

This is for https://phabricator.wikimedia.org/T296282