### PR TITLE
Fix-double encoding of city lookup

### DIFF
--- a/app/Controllers/Validation/FindCitiesController.php
+++ b/app/Controllers/Validation/FindCitiesController.php
@@ -15,6 +15,6 @@ class FindCitiesController {
 		$cities = $ffFactory->newFindCitiesUseCase()
 			->getCitiesForPostcode( $request->get( 'postcode', '' ) );
 
-		return new JsonResponse( array_map( "utf8_encode", $cities ) );
+		return new JsonResponse( $cities );
 	}
 }

--- a/tests/EdgeToEdge/Routes/FindCitiesRouteTest.php
+++ b/tests/EdgeToEdge/Routes/FindCitiesRouteTest.php
@@ -25,6 +25,7 @@ class FindCitiesRouteTest extends WebRouteTestCase {
 			$entityManager->persist( ValidLocation::validLocationForCommunity( '12345', 'Waterford' ) );
 			$entityManager->persist( ValidLocation::validLocationForCommunity( '34567', 'Kildare' ) );
 			$entityManager->persist( ValidLocation::validLocationForCommunity( '12345', 'Wicklow' ) );
+			$entityManager->persist( ValidLocation::validLocationForCommunity( '12345', 'Großröhrsdorf' ) );
 
 			$entityManager->flush();
 
@@ -36,7 +37,7 @@ class FindCitiesRouteTest extends WebRouteTestCase {
 
 			$response = $client->getResponse();
 
-			$this->assertJsonSuccessResponse( [ 'Waterford', 'Wexford', 'Wicklow' ], $response );
+			$this->assertJsonSuccessResponse( [ 'Großröhrsdorf', 'Waterford', 'Wexford', 'Wicklow' ], $response );
 		} );
 	}
 }


### PR DESCRIPTION
Our geodata table for finding cities is already UTF-8 encoded, so we
can pass thru the strings we get from the database, without re-encoding
them.

The change to the integration test is of dubious value: If our database
had the wrong encoding, the storage round trip of special characters
would probably come out fine. I've added it none the less, so show
*potential* behaviour.

This fixes https://phabricator.wikimedia.org/T300132