### PR TITLE
Remove unused code to fix PHPStan errors

### DIFF
--- a/tests/Fixtures/EventDispatcherSpy.php
+++ b/tests/Fixtures/EventDispatcherSpy.php
@@ -10,13 +10,11 @@ use WMDE\Fundraising\MembershipContext\Domain\Event as MembershipEvent;
 
 class EventDispatcherSpy extends EventDispatcher {
 
-	private array $events = [];
-
 	/**
 	 * @param DonationEvent|MembershipEvent $event
 	 */
 	public function dispatch( $event ): void {
-		$this->events[] = $event;
+		// do nothing, currently this class is just for checking that the right event listeners are initilized
 	}
 
 	public function getObservedEventClassNames(): array {


### PR DESCRIPTION
The EventDispatcherSpy stored events but we never checked which events
were fired (that's tested in the use cases). The newest PHPStan version
(updated externally) complained about the unused code.
