### PR TITLE
Ensure string type for PPL custom parameter

### DIFF
--- a/app/Controllers/Payment/PaypalNotificationController.php
+++ b/app/Controllers/Payment/PaypalNotificationController.php
@@ -55,7 +55,7 @@ class PaypalNotificationController {
 
 	private function getValueFromCustomVars( string $customVars, string $key ): string {
 		$vars = json_decode( $customVars, true );
-		return !empty( $vars[$key] ) ? $vars[$key] : '';
+		return !empty( $vars[$key] ) ? strval( $vars[$key] ) : '';
 	}
 
 	private function requestIsForPaymentCompletion( ParameterBag $post ): bool {

--- a/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
@@ -179,7 +179,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 			'address_name' => 'Generous Donor',
 			'item_name' => self::ITEM_NAME,
 			'item_number' => 1,
-			'custom' => '{"sid": "1", "utoken": "my_secret_token"}',
+			'custom' => '{"sid": 1, "utoken": "my_secret_token"}',
 			'txn_id' => '61E67681CH3238416',
 			'payment_type' => 'instant',
 			'txn_type' => 'express_checkout',


### PR DESCRIPTION
The "custom" parameter in a PayPal IPN notification contains
JSON-encoded information with authentication token and donation ID. We
assumed the donation ID would be a string, but in the JSON from PayPal
it was numeric, which created a type error.