### PR TITLE
Fix "make clean" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ download-assets:
 
 clear:
 	rm -rf var/cache/*
-	docker-compose run --rm --no-deps app rm -rf var/cache/*
+	docker-compose run --rm --no-deps app sh -c "rm -rf var/cache/*"
 	docker-compose run --rm --no-deps app chown -R www-data:www-data var/cache/
 
 # n alias to avoid frequent typo


### PR DESCRIPTION
Shell commands with wildcards must be passed as a command string to a
shell, otherwise the wildcard may be interpreted in a wrong context.