### PR TITLE
Remove last crumbs of cookie code

### DIFF
--- a/src/Factories/ChoiceFactory.php
+++ b/src/Factories/ChoiceFactory.php
@@ -27,16 +27,4 @@ class ChoiceFactory {
 		}
 		throw new UnknownChoiceDefinition( 'Address type configuration failure.' );
 	}
-
-	/**
-	 * TODO: Remove this after C21_WMDE_Test_12
-	 *
-	 * @return bool
-	 */
-	public function forceChoiceCookieStorage(): bool {
-		if ( $this->featureToggle->featureIsActive( 'campaigns.optional_cookie_notice.hide' ) ) {
-			return true;
-		}
-		return false;
-	}
 }

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1660,15 +1660,6 @@ class FunFunFactory implements LoggerAwareInterface {
 		return $this->getChoiceFactory()->getAddressType();
 	}
 
-	/**
-	 * TODO: Remove this after C21_WMDE_Test_12
-	 *
-	 * @return bool
-	 */
-	public function forceChoiceCookieStorage(): bool {
-		return $this->getChoiceFactory()->forceChoiceCookieStorage();
-	}
-
 	public function getBucketSelector(): BucketSelector {
 		return $this->createSharedObject( BucketSelector::class, function (): BucketSelector {
 			return new BucketSelector( $this->getCampaignCollection(), new RandomBucketSelection() );


### PR DESCRIPTION
we decided to get rid of the cookie banner after the campaign 2021,
so this code can be removed as well