### PR TITLE
Allow empty payment type for fee validation

### DIFF
--- a/app/Controllers/Validation/ValidateFeeController.php
+++ b/app/Controllers/Validation/ValidateFeeController.php
@@ -11,6 +11,7 @@ use UnexpectedValueException;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\MembershipContext\UseCases\ValidateMembershipFee\ValidateMembershipFeeUseCase;
+use WMDE\Fundraising\PaymentContext\Domain\PaymentType;
 
 class ValidateFeeController {
 
@@ -26,7 +27,9 @@ class ValidateFeeController {
 			$fee->getEuros(),
 			(int)$httpRequest->request->get( 'paymentIntervalInMonths', '0' ),
 			$httpRequest->request->get( 'addressType', '' ),
-			$httpRequest->request->get( 'paymentType', '' )
+			// Until we implement a choice in the frontend, we default to the only payment we support
+			// See https://phabricator.wikimedia.org/T312071
+			$httpRequest->request->get( 'paymentType', PaymentType::DirectDebit->value )
 		);
 
 		if ( $response->isSuccessful() ) {


### PR DESCRIPTION
Currently, the frontend does not send a payment type (because until we
implement https://phabricator.wikimedia.org/T312070 we have only one
payment type), but the new payment domain requires a payment type when
validating (because it's trying to construct a valid Payment
internally).

This problem only occurs in the fee validation. For applying for
memberships the frontend sends a type. For donations we don't have
server-side validation of the amount.