### PR TITLE
Add paymenttype.json translations to membership confirmation page

### DIFF
--- a/app/Controllers/Membership/ApplyForMembershipController.php
+++ b/app/Controllers/Membership/ApplyForMembershipController.php
@@ -29,6 +29,7 @@ class ApplyForMembershipController {
 	public function index( FunFunFactory $ffFactory, Request $httpRequest ): Response {
 		$session = $httpRequest->getSession();
 		$this->ffFactory = $ffFactory;
+		$ffFactory->getTranslationCollector()->addTranslationFile( $ffFactory->getI18nDirectory() . '/messages/paymentTypes.json' );
 		if ( !$ffFactory->getMembershipSubmissionRateLimiter()->isSubmissionAllowed( $session ) ) {
 			return new Response( $this->ffFactory->newSystemMessageResponse( 'membership_application_rejected_limit' ) );
 		}

--- a/app/Controllers/Membership/ShowMembershipConfirmationController.php
+++ b/app/Controllers/Membership/ShowMembershipConfirmationController.php
@@ -12,6 +12,7 @@ use WMDE\Fundraising\MembershipContext\UseCases\ShowApplicationConfirmation\Show
 class ShowMembershipConfirmationController {
 
 	public function index( FunFunFactory $ffFactory, Request $request ): Response {
+		$ffFactory->getTranslationCollector()->addTranslationFile( $ffFactory->getI18nDirectory() . '/messages/paymentTypes.json' );
 		$presenter = $ffFactory->newMembershipApplicationConfirmationHtmlPresenter();
 
 		$useCase = $ffFactory->newMembershipApplicationConfirmationUseCase(
@@ -20,7 +21,6 @@ class ShowMembershipConfirmationController {
 		);
 
 		$useCase->showConfirmation( new ShowAppConfirmationRequest( (int)$request->query->get( 'id', 0 ) ) );
-
 		return new Response( $presenter->getHtml() );
 	}
 }


### PR DESCRIPTION
The frontend code needs the paymentTypes.json translation file to translate
the payment type that should get shown on the membership confirmation page

belongs to ticket: https://phabricator.wikimedia.org/T312072