### PR TITLE
Convert encoding for PayPal requests

### DIFF
--- a/app/Controllers/Payment/PaypalNotificationController.php
+++ b/app/Controllers/Payment/PaypalNotificationController.php
@@ -31,7 +31,10 @@ class PaypalNotificationController {
 		try {
 			$useCase = $ffFactory->newBookDonationUseCase( $this->getUpdateToken( $post ) );
 			$response = $useCase->handleNotification( new NotificationRequest(
-				$post->all(),
+				array_map(
+					fn( $value ) => iconv( 'ISO-8859-1', 'UTF-8', $value ),
+					$post->all()
+				),
 				$this->getDonationId( $post )
 			) );
 			if ( $response->donationWasNotFound() ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "fundraising-application",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/src/Infrastructure/ParameterBagEncodingConverter.php
+++ b/src/Infrastructure/ParameterBagEncodingConverter.php
@@ -9,6 +9,6 @@ class ParameterBagEncodingConverter
 {
 	public static function convert(ParameterBag $input, string $fromEncoding, string $toEncoding = 'UTF-8' ): ParameterBag
 	{
-
+		return $input;
 	}
 }

--- a/src/Infrastructure/ParameterBagEncodingConverter.php
+++ b/src/Infrastructure/ParameterBagEncodingConverter.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace WMDE\Fundraising\Frontend\Infrastructure;
+
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+class ParameterBagEncodingConverter
+{
+	public static function convert(ParameterBag $input, string $fromEncoding, string $toEncoding = 'UTF-8' ): ParameterBag
+	{
+
+	}
+}

--- a/src/Infrastructure/ParameterBagEncodingConverter.php
+++ b/src/Infrastructure/ParameterBagEncodingConverter.php
@@ -1,14 +1,17 @@
 <?php
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace WMDE\Fundraising\Frontend\Infrastructure;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
 
-class ParameterBagEncodingConverter
-{
-	public static function convert(ParameterBag $input, string $fromEncoding, string $toEncoding = 'UTF-8' ): ParameterBag
-	{
-		return $input;
+class ParameterBagEncodingConverter {
+	public static function convert( ParameterBag $input, string $fromEncoding, string $toEncoding = 'UTF-8' ): ParameterBag {
+		return new ParameterBag(
+			array_map(
+				fn( $value ) => iconv( $fromEncoding, $toEncoding, $value ),
+				$input->all()
+			),
+		);
 	}
 }

--- a/src/Infrastructure/ParameterBagEncodingConverter.php
+++ b/src/Infrastructure/ParameterBagEncodingConverter.php
@@ -9,7 +9,7 @@ class ParameterBagEncodingConverter {
 	public static function convert( ParameterBag $input, string $fromEncoding, string $toEncoding = 'UTF-8' ): ParameterBag {
 		return new ParameterBag(
 			array_map(
-				fn( $value ) => iconv( $fromEncoding, $toEncoding, $value ),
+				fn( $value ) => is_string($value) ? iconv( $fromEncoding, $toEncoding, $value ) : $value,
 				$input->all()
 			),
 		);

--- a/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
@@ -487,8 +487,11 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 			$repository->throwOnGetDonationById();
 			$factory->setDonationRepository( $repository );
 
-			$logger = new LoggerSpy();
-			$factory->setPaypalLogger( $logger );
+			$paypalLogger = new LoggerSpy();
+			$mainErrorLogger=new LoggerSpy();
+
+			$factory->setPaypalLogger( $paypalLogger );
+			$factory->setLogger($mainErrorLogger);
 
 			$this->storedDonations()->newStoredIncompletePayPalDonation();
 
@@ -498,11 +501,14 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 				$this->newHttpParamsForPayment()
 			);
 
-			$this->assertSame( 1, $logger->getLogCalls()->count() );
-			$firstCallContext = $logger->getFirstLogCall()->getContext();
+			$this->assertSame( 1, $paypalLogger->getLogCalls()->count() );
+			$firstCallContext = $paypalLogger->getFirstLogCall()->getContext();
 			$this->assertArrayHasKey( 'stacktrace', $firstCallContext );
 			$this->assertArrayHasKey( 'post_vars', $firstCallContext );
-			$this->assertSame( 'An Exception happened: Could not get donation', $logger->getFirstLogCall()->getMessage() );
+			$this->assertSame( 'An Exception happened: Could not get donation', $paypalLogger->getFirstLogCall()->getMessage() );
+
+			$this->assertSame( 1, $mainErrorLogger->getLogCalls()->count() );
+			$this->assertSame( 'An Exception happened: Could not get donation', $mainErrorLogger->getFirstLogCall()->getMessage() );
 		} );
 	}
 

--- a/tests/Unit/Infrastructure/ParameterBagEncodingConverterTest.php
+++ b/tests/Unit/Infrastructure/ParameterBagEncodingConverterTest.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure;
+
+use Symfony\Component\HttpFoundation\ParameterBag;
+use WMDE\Fundraising\Frontend\Infrastructure\ParameterBagEncodingConverter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \WMDE\Fundraising\Frontend\Infrastructure\ParameterBagEncodingConverter
+ */
+class ParameterBagEncodingConverterTest extends TestCase
+{
+	public function testGivenEmptyParameterBagResultIsEmpty(): void {
+		$input = new ParameterBag();
+
+		$result = ParameterBagEncodingConverter::convert( $input,'ISO-8859-1' );
+
+		$this->assertSame( [], $result->all() );
+	}
+}

--- a/tests/Unit/Infrastructure/ParameterBagEncodingConverterTest.php
+++ b/tests/Unit/Infrastructure/ParameterBagEncodingConverterTest.php
@@ -1,32 +1,51 @@
 <?php
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use WMDE\Fundraising\Frontend\Infrastructure\ParameterBagEncodingConverter;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \WMDE\Fundraising\Frontend\Infrastructure\ParameterBagEncodingConverter
  */
-class ParameterBagEncodingConverterTest extends TestCase
-{
-	public function testGivenEmptyParameterBagResultIsEmpty(): void {
+class ParameterBagEncodingConverterTest extends TestCase {
+	public function testGivenEmptyParameterBagThenResultIsEmpty(): void {
 		$input = new ParameterBag();
 
-		$result = ParameterBagEncodingConverter::convert( $input,'ISO-8859-1' );
+		$result = ParameterBagEncodingConverter::convert( $input, 'ISO-8859-1' );
 
 		$this->assertSame( [], $result->all() );
 	}
-	public function testGivenCorrectParameterBAgResultIsConverted():void
-	{
-		$input = new ParameterBag(['Encoded_Value'=>"Bitte \xe4ndern"]);
 
-		// $input="Bitte \xe4ndern";
-		
-		$result = ParameterBagEncodingConverter::convert( $input,'ISO-8859-1');
+	public function testGivenIsoLatin1EncodedParameterBagThenResultIsConverted(): void {
+		$input = new ParameterBag( [ 'Encoded_Value' => "Bitte \xe4ndern" ] );
 
-		$this->assertSame( 'Bitte ändern', $result->get('Encoded_Value') );
+		$result = ParameterBagEncodingConverter::convert( $input, 'ISO-8859-1' );
+
+		$this->assertSame( 'Bitte ändern', $result->get( 'Encoded_Value' ) );
+	}
+
+	/**
+	 * @dataProvider typedValues
+	 */
+	public function testGivenNonStringInParameterBagThenValueShouldBeUntouched( mixed $value ): void {
+		$input = new ParameterBag( ['some_value' => $value] );
+
+		$result = ParameterBagEncodingConverter::convert( $input, 'ISO-8859-1' );
+
+		$this->assertSame( $value, $result->get('some_value') );
+	}
+
+	/**
+	 * @return iterable<string,mixed>
+	 */
+	public function typedValues(): iterable {
+		yield 'Numeric String' => [ '44' ];
+		yield 'Int' => [ 27 ];
+		yield 'Float' => [ 3.14 ];
+		yield 'Boolean' => [ false ];
+		yield 'null' => [ null ];
 	}
 }

--- a/tests/Unit/Infrastructure/ParameterBagEncodingConverterTest.php
+++ b/tests/Unit/Infrastructure/ParameterBagEncodingConverterTest.php
@@ -19,4 +19,14 @@ class ParameterBagEncodingConverterTest extends TestCase
 
 		$this->assertSame( [], $result->all() );
 	}
+	public function testGivenCorrectParameterBAgResultIsConverted():void
+	{
+		$input = new ParameterBag(['Encoded_Value'=>"Bitte \xe4ndern"]);
+
+		// $input="Bitte \xe4ndern";
+		
+		$result = ParameterBagEncodingConverter::convert( $input,'ISO-8859-1');
+
+		$this->assertSame( 'Bitte ändern', $result->get('Encoded_Value') );
+	}
 }


### PR DESCRIPTION
Convert data that PayPal sends us from ISO-8859-1 to UTF-8. This is not the best solution - we should have some indication of what encoding PayPal actually sends us.

Ticket: https://phabricator.wikimedia.org/T319386