### PR TITLE
Convert encoding for PayPal requests

### DIFF
--- a/app/Controllers/Payment/PaypalNotificationController.php
+++ b/app/Controllers/Payment/PaypalNotificationController.php
@@ -31,7 +31,10 @@ class PaypalNotificationController {
 		try {
 			$useCase = $ffFactory->newBookDonationUseCase( $this->getUpdateToken( $post ) );
 			$response = $useCase->handleNotification( new NotificationRequest(
-				$post->all(),
+				array_map(
+					fn( $value ) => iconv( 'ISO-8859-1', 'UTF-8', $value ),
+					$post->all()
+				),
 				$this->getDonationId( $post )
 			) );
 			if ( $response->donationWasNotFound() ) {


### PR DESCRIPTION
Convert data that PayPal sends us from ISO-8859-1 to UTF-8. This is not the best solution - we should have some indication of what encoding PayPal actually sends us.

This pull request is a quick-fix meant for fast deployment. We'll improve the code in #2601 and further changes in the Payment bounded context.

Ticket: https://phabricator.wikimedia.org/T319386