### PR TITLE
Inject native Symfony mailer in FunFunFactory

### DIFF
--- a/.docker/app/config.dev.json
+++ b/.docker/app/config.dev.json
@@ -109,11 +109,5 @@
   "user-data-key": "q+57eBH3k9alQE4k45PMXpuTRKj+/n+woQvD7AXQMps=",
   "campaigns": {
     "configurations": [ "campaigns.yml", "campaigns.dev.yml" ]
-  },
-  "smtp": {
-    "host": "mailhog",
-    "username": "NOT A USERNAME",
-    "password": "NOT A PASSWORD",
-    "port": 1025
   }
 }

--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -136,12 +136,5 @@
 	"campaigns": {
 		"timezone":  "Europe/Berlin",
 		"configurations": [ "campaigns.yml" ]
-	},
-	"smtp": {
-		"host": "localhost",
-		"username": "",
-		"password": "",
-		"port": 25,
-		"encryption": ""
 	}
 }

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -95,11 +95,5 @@
 			"campaigns.yml",
 			"campaigns.test.yml"
 		]
-	},
-	"smtp": {
-		"host": "localhost",
-		"username": "NOT A USERNAME",
-		"password": "NOT A PASSWORD",
-		"port": 25
 	}
 }

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -778,38 +778,6 @@
       },
       "additionalProperties": false,
       "required": [ "donations", "membership" ]
-    },
-    "smtp": {
-      "type": "object",
-      "title": "SMTP configuration",
-      "properties": {
-        "host": {
-          "type": "string",
-          "title": "SMTP host",
-          "default": "localhost"
-        },
-        "username": {
-          "type": "string",
-          "title": "SMTP username",
-          "minLength": 8
-        },
-        "password": {
-          "type": "string",
-          "title": "SMTP password",
-          "minLength": 8
-        },
-        "port": {
-          "type": "integer",
-          "title": "SMTP port",
-          "default": 25
-        },
-        "encryption": {
-          "type": "string",
-          "title": "'tls' or empty string"
-        }
-      },
-      "additionalProperties": false,
-      "required": [ "host", "username", "password", "port", "encryption" ]
     }
   },
   "additionalProperties": false,
@@ -834,7 +802,6 @@
     "piwik",
     "payment-types",
     "cookie",
-    "preset-amounts",
-    "smtp"
+    "preset-amounts"
   ]
 }

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -15,3 +15,6 @@ framework:
     #fragments: true
     php_errors:
         log: true
+
+    mailer:
+        dsn: 'native://default'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -81,6 +81,7 @@ services:
         public: true
         calls:
             - setUrlGenerator: ["@app.url_generator"]
+            - setMailer: ["@mailer"]
 
     WMDE\Fundraising\Frontend\App\UrlGeneratorAdapter:
         class: WMDE\Fundraising\Frontend\App\UrlGeneratorAdapter

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -39,7 +39,6 @@ use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mailer\Transport\NullTransport;
-use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Twig\Environment;
 use WMDE\Clock\SystemClock;
 use WMDE\EmailAddress\EmailAddress;
@@ -777,15 +776,13 @@ class FunFunFactory implements LoggerAwareInterface {
 	}
 
 	private function getMailer(): MailerInterface {
-		return $this->createSharedObject( MailerInterface::class, function (): MailerInterface {
-			$transport = new EsmtpTransport(
-				$this->config['smtp']['host'],
-				$this->config['smtp']['port'],
-			);
-			$transport->setUsername( $this->config['smtp']['username'] )
-				->setPassword( $this->config['smtp']['password'] );
-			return new Mailer( $transport );
+		return $this->createSharedObject( MailerInterface::class, static function (): MailerInterface {
+			return new Mailer( new NullTransport() );
 		} );
+	}
+
+	public function setMailer( MailerInterface $mailer ): void {
+		$this->sharedObjects[ MailerInterface::class ] = $mailer;
 	}
 
 	public function setNullMessenger(): void {


### PR DESCRIPTION
Add setter for Symfony mailer in FunFunFactory and remove creating a SMTP mailer transport from the configuration.

Add default mailer configuration to the framework configuration. We're using the "Native mailer" (a wrapper for the PHP `mail` command). In production we have a postfix setup that will forward the emails to email.wikipedia.de. In our dev environment, the sendmail replacement in our Docker containers will deliver the mail to the MailHog container.

Ticket: https://phabricator.wikimedia.org/T321559