### PR TITLE
Add Makefile target for updating content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ install-php:
 update-php:
 	docker run --rm $(DOCKER_FLAGS) --volume $(BUILD_DIR):/app -w /app --volume ~/.composer:/composer --user $(current_user):$(current_group) $(DOCKER_IMAGE):composer composer update $(COMPOSER_FLAGS)
 
+update-content:
+	docker run --rm $(DOCKER_FLAGS) --volume $(BUILD_DIR):/app -w /app --volume ~/.composer:/composer --user $(current_user):$(current_group) $(DOCKER_IMAGE):composer composer update wmde/fundraising-frontend-content
+
+
 generate-database-schema:
 	$(DOCTRINE_SCHEMA_COMMAND) > ./.docker/database/01.Database_Schema.sql
 

--- a/README.md
+++ b/README.md
@@ -347,13 +347,18 @@ JavaScript) reference with the value of `assets-path`.
 
 ## Updating the dependencies
 
-To update all the PHP dependencies, run
+To update *all* the PHP dependencies, run
 
     make update-php
 
-For updating an individual package, use the command line
+To update only the messages in the application and emails, update the
+[fundraising-frontend-content dependency](https://github.com/wmde/fundraising-frontend-content) with the command
 
-    docker run --rm -it -v $(pwd):/app -v ~/.composer:/composer -u $(id -u):$(id -g) composer update --ignore-platform-reqs PACKAGE_NAME
+	make update-content
+
+For updating an individual PHP dependency, use the command line
+
+    docker run --rm -it -v $(pwd):/app -u $(id -u):$(id -g) registry.gitlab.com/fun-tech/fundraising-frontend-docker:composer composer update PACKAGE_NAME
 
 and replace the `PACKAGE_NAME` placeholder with the name of your package.
 


### PR DESCRIPTION
Add a Makefile target for updating content, leaving all other
dependencies alone. Use this target whenever you want to pull in the
newest changes in the content repository.
