### PR TITLE
Clean up old A/B testing campaigns

### DIFF
--- a/app/Controllers/Donation/NewDonationController.php
+++ b/app/Controllers/Donation/NewDonationController.php
@@ -38,7 +38,7 @@ class NewDonationController {
 				$interval,
 				$validationResult->isSuccessful(),
 				$trackingInfo,
-				$request->get( 'addressType', $ffFactory->getAddressType() ),
+				$request->get( 'addressType' ),
 				Routes::getNamedRouteUrls( $ffFactory->getUrlGenerator() )
 			)
 		);

--- a/app/config/archived_campaigns.yaml
+++ b/app/config/archived_campaigns.yaml
@@ -132,3 +132,60 @@ confirmation_page_layout:
   url_key: confirmation
   active: true
   param_only: false
+
+address_type:
+  description: Test if the address type not being preselected changes the user behaviour of entering nonsense address data.
+  reference: "https://phabricator.wikimedia.org/T247228"
+  start: "2020-09-15"
+  end: "2020-11-02"
+  buckets:
+    - "preselection"
+    - "no_preselection"
+  default_bucket: "no_preselection"
+  url_key: addrpre
+  active: false
+  param_only: false
+
+address_provision_options:
+  description: Test adding provisional address type options before choosing a donor type. (Adds "e-mail only" option)
+  reference: "https://phabricator.wikimedia.org/T260023"
+  start: "2020-10-01"
+  end: "2020-12-31"
+  buckets:
+    - "old_address_type_options"
+    - "provisional_address_options"
+  default_bucket: "old_address_type_options"
+  url_key: provadd
+  active: true
+  param_only: true
+
+address_type_steps:
+  description: Test different texts for the multistep address type
+  reference: "https://phabricator.wikimedia.org/T291362"
+  start: "2021-10-07"
+  end: "2021-12-31"
+  buckets:
+    - "direct"
+    - "multistep"
+    - "multistep_var"
+    - "multistep_checkmarks"
+    - "require_address"
+  default_bucket: "direct"
+  url_key: ast
+  active: true
+  param_only: true
+
+optional_cookie_notice:
+  description: Test what effect the cookie notice has on donations
+  reference: "https://phabricator.wikimedia.org/T295869"
+  start: "2021-11-18"
+  end: "2021-12-31"
+  buckets:
+    - "show"
+    - "hide"
+  default_bucket: "show"
+  url_key: ocn
+  active: true
+  param_only: true
+
+

--- a/app/config/campaigns.dev.yml
+++ b/app/config/campaigns.dev.yml
@@ -1,21 +1,7 @@
 # This file is used in the "dev" and "uat" environments to be able to test future and past campaigns
 campaigns:
 
-  address_type:
-    active: false
-    start: "2020-09-15"
-
-  address_provision_options:
-    active: true
-    start: "2020-09-20"
-    default_bucket: "provisional_address_options"
-
   address_type_steps:
     active: true
-    start: "2021-09-01"
+    start: "2022-11-01"
     default_bucket: "direct"
-
-  optional_cookie_notice:
-    active: true
-    start: "2021-01-01"
-    default_bucket: "show"

--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -22,57 +22,17 @@ campaigns:
     # url_key: URL parameter key used for assigning buckets to people
     # param_only: (Optional) Set to true if the campaign should return the default bucket when the url key is not in a request. This is for A/B tests triggered by banners
 
-    address_type:
-      description: Test if the address type not being preselected changes the user behaviour of entering nonsense address data.
-      reference: "https://phabricator.wikimedia.org/T247228"
-      start: "2020-09-15"
-      end: "2020-11-02"
-      buckets:
-        - "preselection"
-        - "no_preselection"
-      default_bucket: "no_preselection"
-      url_key: addrpre
-      active: false
-      param_only: false
-
-    address_provision_options:
-      description: Test adding provisional address type options before choosing a donor type. (Adds "e-mail only" option)
-      reference: "https://phabricator.wikimedia.org/T260023"
-      start: "2020-10-01"
-      end: "2020-12-31"
-      buckets:
-        - "old_address_type_options"
-        - "provisional_address_options"
-      default_bucket: "old_address_type_options"
-      url_key: provadd
-      active: true
-      param_only: true
 
     address_type_steps:
-      description: Test different texts for the multistep address type
-      reference: "https://phabricator.wikimedia.org/T291362"
-      start: "2021-10-07"
-      end: "2021-12-31"
+      description: Test Donating with E-Mail only
+      reference: "https://phabricator.wikimedia.org/T322415"
+      start: "2022-11-07"
+      end: "2022-12-31"
       buckets:
         - "direct"
-        - "multistep"
-        - "multistep_var"
-        - "multistep_checkmarks"
         - "require_address"
       default_bucket: "direct"
       url_key: ast
       active: true
       param_only: true
 
-    optional_cookie_notice:
-      description: Test what effect the cookie notice has on donations
-      reference: "https://phabricator.wikimedia.org/T295869"
-      start: "2021-11-18"
-      end: "2021-12-31"
-      buckets:
-        - "show"
-        - "hide"
-      default_bucket: "show"
-      url_key: ocn
-      active: true
-      param_only: true

--- a/src/Factories/ChoiceFactory.php
+++ b/src/Factories/ChoiceFactory.php
@@ -13,18 +13,9 @@ use WMDE\Fundraising\Frontend\BucketTesting\FeatureToggle;
  */
 class ChoiceFactory {
 
-	private $featureToggle;
+	private FeatureToggle $featureToggle;
 
 	public function __construct( FeatureToggle $featureToggle ) {
 		$this->featureToggle = $featureToggle;
-	}
-
-	public function getAddressType(): ?string {
-		if ( $this->featureToggle->featureIsActive( 'campaigns.address_type.no_preselection' ) ) {
-			return null;
-		} elseif ( $this->featureToggle->featureIsActive( 'campaigns.address_type.preselection' ) ) {
-			return 'person';
-		}
-		throw new UnknownChoiceDefinition( 'Address type configuration failure.' );
 	}
 }

--- a/src/Factories/ChoiceFactory.php
+++ b/src/Factories/ChoiceFactory.php
@@ -13,6 +13,13 @@ use WMDE\Fundraising\Frontend\BucketTesting\FeatureToggle;
  */
 class ChoiceFactory {
 
+	/**
+	 * @var FeatureToggle
+	 *
+	 * To save us having to delete and recreate this class, this is ignored
+	 * until the next time we need to A/B test a feature in the application.
+	 * @phpstan-ignore-next-line
+	 */
 	private FeatureToggle $featureToggle;
 
 	public function __construct( FeatureToggle $featureToggle ) {

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1678,10 +1678,6 @@ class FunFunFactory implements LoggerAwareInterface {
 		} );
 	}
 
-	public function getAddressType(): ?string {
-		return $this->getChoiceFactory()->getAddressType();
-	}
-
 	public function getBucketSelector(): BucketSelector {
 		return $this->createSharedObject( BucketSelector::class, function (): BucketSelector {
 			return new BucketSelector( $this->getCampaignCollection(), new RandomBucketSelection() );


### PR DESCRIPTION
Move old campaigns to archived_campaigns.yml

Prepare address_type_steps for new test (see https://phabricator.wikimedia.org/T322415)

Ticket: https://phabricator.wikimedia.org/T298318
