### PR TITLE
Avoid PayPal error-retry loops for booked payments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"wmde/email-address": "~1.0",
 		"wmde/euro": "~1.0",
 		"wmde/clock": "~1.0",
-		"wmde/fundraising-donations": "~11.0",
+		"wmde/fundraising-donations": "dev-special-booking-failure-message",
 		"wmde/fundraising-memberships": "~10.0",
 		"wmde/fundraising-payments": "~5.0",
 		"wmde/fundraising-subscriptions": "~3.1",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"wmde/email-address": "~1.0",
 		"wmde/euro": "~1.0",
 		"wmde/clock": "~1.0",
-		"wmde/fundraising-donations": "dev-special-booking-failure-message",
+		"wmde/fundraising-donations": "~11.1",
 		"wmde/fundraising-memberships": "~10.0",
 		"wmde/fundraising-payments": "~5.0",
 		"wmde/fundraising-subscriptions": "~3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb9e560f43833c3a866df2fc2c4a3b7f",
+    "content-hash": "6011951ed6c9a448f68fc4ead1f92f4b",
     "packages": [
         {
             "name": "airbrake/phpbrake",
@@ -1235,16 +1235,16 @@
         },
         {
             "name": "doctrine/persistence",
-            "version": "3.0.4",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "05612da375f8a3931161f435f91d6704926e6ec5"
+                "reference": "2a9c70a5e21f8968c5a46b79f819ea52f322080b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/05612da375f8a3931161f435f91d6704926e6ec5",
-                "reference": "05612da375f8a3931161f435f91d6704926e6ec5",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/2a9c70a5e21f8968c5a46b79f819ea52f322080b",
+                "reference": "2a9c70a5e21f8968c5a46b79f819ea52f322080b",
                 "shasum": ""
             },
             "require": {
@@ -1315,7 +1315,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/persistence/issues",
-                "source": "https://github.com/doctrine/persistence/tree/3.0.4"
+                "source": "https://github.com/doctrine/persistence/tree/3.1.0"
             },
             "funding": [
                 {
@@ -1331,7 +1331,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-13T07:34:14+00:00"
+            "time": "2022-11-18T14:10:19+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -1546,16 +1546,16 @@
         },
         {
             "name": "gedmo/doctrine-extensions",
-            "version": "v3.9.0",
+            "version": "v3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine-extensions/DoctrineExtensions.git",
-                "reference": "d869cf11f12995b27fa6486ec2a860cc76c46988"
+                "reference": "5a956a448f67b917b05958429b224e8955dc9b8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine-extensions/DoctrineExtensions/zipball/d869cf11f12995b27fa6486ec2a860cc76c46988",
-                "reference": "d869cf11f12995b27fa6486ec2a860cc76c46988",
+                "url": "https://api.github.com/repos/doctrine-extensions/DoctrineExtensions/zipball/5a956a448f67b917b05958429b224e8955dc9b8c",
+                "reference": "5a956a448f67b917b05958429b224e8955dc9b8c",
                 "shasum": ""
             },
             "require": {
@@ -1563,7 +1563,7 @@
                 "doctrine/annotations": "^1.13",
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.13 || ^3.0",
-                "doctrine/event-manager": "^1.0",
+                "doctrine/event-manager": "^1.2",
                 "doctrine/persistence": "^2.2 || ^3.0",
                 "php": "^7.2 || ^8.0",
                 "psr/cache": "^1 || ^2 || ^3",
@@ -1600,7 +1600,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.10-dev"
+                    "dev-main": "3.11-dev"
                 }
             },
             "autoload": {
@@ -1646,10 +1646,10 @@
             "support": {
                 "email": "gediminas.morkevicius@gmail.com",
                 "issues": "https://github.com/doctrine-extensions/DoctrineExtensions/issues",
-                "source": "https://github.com/doctrine-extensions/DoctrineExtensions/tree/v3.9.0",
+                "source": "https://github.com/doctrine-extensions/DoctrineExtensions/tree/v3.10.0",
                 "wiki": "https://github.com/Atlantic18/DoctrineExtensions/tree/main/doc"
             },
-            "time": "2022-09-22T02:37:53+00:00"
+            "time": "2022-11-14T20:25:40+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -2135,16 +2135,16 @@
         },
         {
             "name": "laminas/laminas-code",
-            "version": "4.7.0",
+            "version": "4.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-code.git",
-                "reference": "0337d9265bc2e6376babad8c511500821620cb30"
+                "reference": "91aabc066d5620428120800c0eafc0411e441a62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/0337d9265bc2e6376babad8c511500821620cb30",
-                "reference": "0337d9265bc2e6376babad8c511500821620cb30",
+                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/91aabc066d5620428120800c0eafc0411e441a62",
+                "reference": "91aabc066d5620428120800c0eafc0411e441a62",
                 "shasum": ""
             },
             "require": {
@@ -2197,7 +2197,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-09-13T10:33:30+00:00"
+            "time": "2022-11-21T01:32:31+00:00"
         },
         {
             "name": "micropayment-de/service-client",
@@ -5016,16 +5016,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4"
+                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
-                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
+                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
                 "shasum": ""
             },
             "require": {
@@ -5040,7 +5040,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5078,7 +5078,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -5094,20 +5094,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "433d05519ce6990bf3530fba6957499d327395c2"
+                "reference": "511a08c03c1960e08a883f4cffcacd219b758354"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/433d05519ce6990bf3530fba6957499d327395c2",
-                "reference": "433d05519ce6990bf3530fba6957499d327395c2",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354",
+                "reference": "511a08c03c1960e08a883f4cffcacd219b758354",
                 "shasum": ""
             },
             "require": {
@@ -5119,7 +5119,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5159,7 +5159,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -5175,7 +5175,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
@@ -5266,16 +5266,16 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "219aa369ceff116e673852dce47c3a41794c14bd"
+                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/219aa369ceff116e673852dce47c3a41794c14bd",
-                "reference": "219aa369ceff116e673852dce47c3a41794c14bd",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6",
+                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6",
                 "shasum": ""
             },
             "require": {
@@ -5287,7 +5287,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5330,7 +5330,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -5346,20 +5346,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e"
+                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
-                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
+                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
                 "shasum": ""
             },
             "require": {
@@ -5374,7 +5374,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5413,7 +5413,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -5429,20 +5429,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "bf44a9fd41feaac72b074de600314a93e2ae78e2"
+                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/bf44a9fd41feaac72b074de600314a93e2ae78e2",
-                "reference": "bf44a9fd41feaac72b074de600314a93e2ae78e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/869329b1e9894268a8a61dabb69153029b7a8c97",
+                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97",
                 "shasum": ""
             },
             "require": {
@@ -5451,7 +5451,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5489,7 +5489,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -5505,20 +5505,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace"
+                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/cfa0ae98841b9e461207c13ab093d76b0fa7bace",
-                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
                 "shasum": ""
             },
             "require": {
@@ -5527,7 +5527,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5572,7 +5572,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -5588,7 +5588,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-10T07:21:04+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
@@ -7195,16 +7195,16 @@
         },
         {
             "name": "wmde/fundraising-donations",
-            "version": "v11.0.0",
+            "version": "dev-special-booking-failure-message",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-donations",
-                "reference": "99083884d490be819ea9dc0e4dc63b8b5c7df7a7"
+                "reference": "21f272a0551a54d805bcede53753f209d585eeeb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-donations/zipball/99083884d490be819ea9dc0e4dc63b8b5c7df7a7",
-                "reference": "99083884d490be819ea9dc0e4dc63b8b5c7df7a7",
+                "url": "https://api.github.com/repos/wmde/fundraising-donations/zipball/21f272a0551a54d805bcede53753f209d585eeeb",
+                "reference": "21f272a0551a54d805bcede53753f209d585eeeb",
                 "shasum": ""
             },
             "require": {
@@ -7219,7 +7219,7 @@
                 "wmde/euro": "~1.0",
                 "wmde/freezable-value-object": "~2.0",
                 "wmde/fun-validators": "~4.0",
-                "wmde/fundraising-payments": "~5.0"
+                "wmde/fundraising-payments": "~5.3"
             },
             "require-dev": {
                 "ext-pdo_sqlite": "*",
@@ -7252,7 +7252,7 @@
             ],
             "description": "Bounded Context for the Wikimedia Deutschland fundraising donation subdomain",
             "homepage": "https://github.com/wmde/fundraising-donations",
-            "time": "2022-08-30T07:33:45+00:00"
+            "time": "2022-11-23T09:40:21+00:00"
         },
         {
             "name": "wmde/fundraising-memberships",
@@ -7316,16 +7316,16 @@
         },
         {
             "name": "wmde/fundraising-payments",
-            "version": "5.2.1",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-payments",
-                "reference": "92722797831fecd163a0c3a7af95c54f9586ec21"
+                "reference": "afd58d8eeeae03f5534cf6788ae2d83992c1cf53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-payments/zipball/92722797831fecd163a0c3a7af95c54f9586ec21",
-                "reference": "92722797831fecd163a0c3a7af95c54f9586ec21",
+                "url": "https://api.github.com/repos/wmde/fundraising-payments/zipball/afd58d8eeeae03f5534cf6788ae2d83992c1cf53",
+                "reference": "afd58d8eeeae03f5534cf6788ae2d83992c1cf53",
                 "shasum": ""
             },
             "require": {
@@ -7367,7 +7367,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Bounded Context for the Wikimedia Deutschland fundraising payment subdomain",
-            "time": "2022-10-21T16:32:16+00:00"
+            "time": "2022-11-23T12:05:46+00:00"
         },
         {
             "name": "wmde/fundraising-subscriptions",
@@ -10163,6 +10163,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "wmde/fundraising-donations": 20,
         "remotelyliving/doorkeeper": 20,
         "wmde/fundraising-frontend-content": 20
     },
@@ -10178,5 +10179,5 @@
     "platform-dev": {
         "ext-pdo_sqlite": "*"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6011951ed6c9a448f68fc4ead1f92f4b",
+    "content-hash": "625f20992b1388c7eabd7cf6e86b192b",
     "packages": [
         {
             "name": "airbrake/phpbrake",
@@ -1135,16 +1135,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "2.13.3",
+            "version": "2.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "e750360bd52b080c4cbaaee1b48b80f7dc873b36"
+                "reference": "a5a6cc6630ce497290396d5f206887227820a634"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/e750360bd52b080c4cbaaee1b48b80f7dc873b36",
-                "reference": "e750360bd52b080c4cbaaee1b48b80f7dc873b36",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/a5a6cc6630ce497290396d5f206887227820a634",
+                "reference": "a5a6cc6630ce497290396d5f206887227820a634",
                 "shasum": ""
             },
             "require": {
@@ -1173,13 +1173,13 @@
                 "doctrine/annotations": "^1.13",
                 "doctrine/coding-standard": "^9.0.2 || ^10.0",
                 "phpbench/phpbench": "^0.16.10 || ^1.0",
-                "phpstan/phpstan": "~1.4.10 || 1.8.5",
+                "phpstan/phpstan": "~1.4.10 || 1.9.2",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
                 "psr/log": "^1 || ^2 || ^3",
                 "squizlabs/php_codesniffer": "3.7.1",
                 "symfony/cache": "^4.4 || ^5.4 || ^6.0",
                 "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-                "vimeo/psalm": "4.27.0"
+                "vimeo/psalm": "4.30.0"
             },
             "suggest": {
                 "ext-dom": "Provides support for XSD validation for XML mapping files",
@@ -1229,9 +1229,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/2.13.3"
+                "source": "https://github.com/doctrine/orm/tree/2.13.4"
             },
-            "time": "2022-10-07T06:37:17+00:00"
+            "time": "2022-11-20T18:53:31+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -7195,16 +7195,16 @@
         },
         {
             "name": "wmde/fundraising-donations",
-            "version": "dev-special-booking-failure-message",
+            "version": "v11.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-donations",
-                "reference": "21f272a0551a54d805bcede53753f209d585eeeb"
+                "reference": "1c268112e89895392df13c3350ad7a5baf2d89a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-donations/zipball/21f272a0551a54d805bcede53753f209d585eeeb",
-                "reference": "21f272a0551a54d805bcede53753f209d585eeeb",
+                "url": "https://api.github.com/repos/wmde/fundraising-donations/zipball/1c268112e89895392df13c3350ad7a5baf2d89a3",
+                "reference": "1c268112e89895392df13c3350ad7a5baf2d89a3",
                 "shasum": ""
             },
             "require": {
@@ -7252,7 +7252,7 @@
             ],
             "description": "Bounded Context for the Wikimedia Deutschland fundraising donation subdomain",
             "homepage": "https://github.com/wmde/fundraising-donations",
-            "time": "2022-11-23T09:40:21+00:00"
+            "time": "2022-11-28T12:29:47+00:00"
         },
         {
             "name": "wmde/fundraising-memberships",
@@ -10163,7 +10163,6 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "wmde/fundraising-donations": 20,
         "remotelyliving/doorkeeper": 20,
         "wmde/fundraising-frontend-content": 20
     },

--- a/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Tests\EdgeToEdge\Routes;
 
-use Symfony\Bundle\FrameworkBundle\KernelBrowser as Client;
 use Symfony\Component\HttpFoundation\Request;
 use WMDE\Fundraising\DonationContext\Tests\Fixtures\ThrowingDonationRepository;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
@@ -35,59 +34,59 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 	}
 
 	public function testGivenValidRequest_applicationIndicatesSuccess(): void {
-		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ): void {
-			$this->setSucceedingDonationTokenGenerator( $factory );
-			$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$this->setSucceedingDonationTokenGenerator( $factory );
+		$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
 
-			$this->storedDonations()->newStoredIncompletePayPalDonation();
+		$this->storedDonations()->newStoredIncompletePayPalDonation();
 
-			$client->request(
-				Request::METHOD_POST,
-				self::PATH,
-				$this->newHttpParamsForPayment()
-			);
+		$client->request(
+			Request::METHOD_POST,
+			self::PATH,
+			$this->newHttpParamsForPayment()
+		);
 
-			$this->assertSame( 200, $client->getResponse()->getStatusCode() );
-			$this->assertPayPalDataGotPersisted( $this->newHttpParamsForPayment() );
-		} );
+		$this->assertSame( 200, $client->getResponse()->getStatusCode() );
+		$this->assertPayPalDataGotPersisted( $this->newHttpParamsForPayment() );
 	}
 
 	public function testGivenRequestWithMissingItemId_getsIdFromCustomArray(): void {
-		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ): void {
-			$this->setSucceedingDonationTokenGenerator( $factory );
-			$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$this->setSucceedingDonationTokenGenerator( $factory );
+		$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
 
-			$this->storedDonations()->newStoredIncompletePayPalDonation();
+		$this->storedDonations()->newStoredIncompletePayPalDonation();
 
-			$request = $this->newHttpParamsForPayment();
-			$request['item_number'] = '';
+		$request = $this->newHttpParamsForPayment();
+		$request['item_number'] = '';
 
-			$client->request(
-				Request::METHOD_POST,
-				self::PATH,
-				$request
-			);
+		$client->request(
+			Request::METHOD_POST,
+			self::PATH,
+			$request
+		);
 
-			$this->assertSame( 200, $client->getResponse()->getStatusCode() );
-			$this->assertPayPalDataGotPersisted( $this->newHttpParamsForPayment() );
-		} );
+		$this->assertSame( 200, $client->getResponse()->getStatusCode() );
+		$this->assertPayPalDataGotPersisted( $this->newHttpParamsForPayment() );
 	}
 
 	public function testGivenValidRequestToLegacyPath_applicationIndicatesSuccess(): void {
-		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ): void {
-			$this->setSucceedingDonationTokenGenerator( $factory );
-			$this->storedDonations()->newStoredIncompletePayPalDonation();
-			$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$this->setSucceedingDonationTokenGenerator( $factory );
+		$this->storedDonations()->newStoredIncompletePayPalDonation();
+		$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
 
-			$client->request(
-				Request::METHOD_POST,
-				self::LEGACY_PATH,
-				$this->newHttpParamsForPayment()
-			);
+		$client->request(
+			Request::METHOD_POST,
+			self::LEGACY_PATH,
+			$this->newHttpParamsForPayment()
+		);
 
-			$this->assertSame( 200, $client->getResponse()->getStatusCode() );
-			$this->assertPayPalDataGotPersisted( $this->newHttpParamsForPayment() );
-		} );
+		$this->assertSame( 200, $client->getResponse()->getStatusCode() );
+		$this->assertPayPalDataGotPersisted( $this->newHttpParamsForPayment() );
 	}
 
 	private function assertPayPalDataGotPersisted( array $request ): void {
@@ -134,71 +133,71 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 	}
 
 	public function testGivenInvalidReceiverEmail_applicationReturnsError(): void {
-		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ): void {
-			$this->setSucceedingDonationTokenGenerator( $factory );
-			$this->storedDonations()->newStoredIncompletePayPalDonation();
-			$factory->setVerificationServiceFactory(
-				new FailingVerificationServiceFactory( PayPalVerificationService::ERROR_WRONG_RECEIVER )
-			);
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$this->setSucceedingDonationTokenGenerator( $factory );
+		$this->storedDonations()->newStoredIncompletePayPalDonation();
+		$factory->setVerificationServiceFactory(
+			new FailingVerificationServiceFactory( PayPalVerificationService::ERROR_WRONG_RECEIVER )
+		);
 
-			$request = $this->newHttpParamsForPayment();
-			$request['receiver_email'] = 'mr.robot@evilcorp.com';
+		$request = $this->newHttpParamsForPayment();
+		$request['receiver_email'] = 'mr.robot@evilcorp.com';
 
-			$client->request(
-				Request::METHOD_POST,
-				self::PATH,
-				$request
-			);
+		$client->request(
+			Request::METHOD_POST,
+			self::PATH,
+			$request
+		);
 
-			$this->assertSame( 'Payment receiver address does not match', $client->getResponse()->getContent() );
-			$this->assertSame( 403, $client->getResponse()->getStatusCode() );
-		} );
+		$this->assertSame( 'Payment receiver address does not match', $client->getResponse()->getContent() );
+		$this->assertSame( 403, $client->getResponse()->getStatusCode() );
 	}
 
 	/**
 	 * @dataProvider unsupportedPaymentStatusProvider
 	 */
 	public function testGivenUnsupportedPaymentStatus_applicationReturnsOK( array $params ): void {
-		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ) use ( $params ): void {
-			$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
 
-			$client->request(
-				Request::METHOD_POST,
-				self::PATH,
-				$params
-			);
+		$client->request(
+			Request::METHOD_POST,
+			self::PATH,
+			$params
+		);
 
-			$this->assertSame( '', $client->getResponse()->getContent() );
-			$this->assertSame( 200, $client->getResponse()->getStatusCode() );
-		} );
+		$this->assertSame( '', $client->getResponse()->getContent() );
+		$this->assertSame( 200, $client->getResponse()->getStatusCode() );
 	}
 
 	/**
 	 * @dataProvider unsupportedPaymentStatusProvider
 	 */
 	public function testGivenUnsupportedPaymentStatus_requestDataIsLogged( array $params, string $paymentStatus ): void {
-		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ) use ( $params, $paymentStatus ): void {
-			$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
 
-			$logger = new LoggerSpy();
-			$factory->setPaypalLogger( $logger );
+		$logger = new LoggerSpy();
+		$factory->setPaypalLogger( $logger );
 
-			$client->request(
-				Request::METHOD_POST,
-				self::PATH,
-				$params
-			);
+		$client->request(
+			Request::METHOD_POST,
+			self::PATH,
+			$params
+		);
 
-			$this->assertSame(
-				[ 'PayPal request not handled' ],
-				$logger->getLogCalls()->getMessages()
-			);
+		$this->assertSame(
+			[ 'PayPal request not handled' ],
+			$logger->getLogCalls()->getMessages()
+		);
 
-			$this->assertSame(
-				$paymentStatus,
-				$logger->getLogCalls()->getFirstCall()->getContext()['post_vars']['payment_status']
-			);
-		} );
+		$this->assertSame(
+			$paymentStatus,
+			$logger->getLogCalls()->getFirstCall()->getContext()['post_vars']['payment_status']
+		);
 	}
 
 	public function unsupportedPaymentStatusProvider(): \Iterator {
@@ -208,109 +207,109 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 	}
 
 	public function testGivenPersonalPaypalInfosOnError_PrivateInfoIsExcludedFromGettingLogged(): void {
-		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ): void {
-			$this->setSucceedingDonationTokenGenerator( $factory );
-			$factory->setVerificationServiceFactory(
-				new FailingVerificationServiceFactory( PayPalVerificationService::ERROR_UNSUPPORTED_CURRENCY )
-			);
-			$this->storedDonations()->newStoredIncompletePayPalDonation();
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$this->setSucceedingDonationTokenGenerator( $factory );
+		$factory->setVerificationServiceFactory(
+			new FailingVerificationServiceFactory( PayPalVerificationService::ERROR_UNSUPPORTED_CURRENCY )
+		);
+		$this->storedDonations()->newStoredIncompletePayPalDonation();
 
-			$logger = new LoggerSpy();
-			$factory->setPaypalLogger( $logger );
+		$logger = new LoggerSpy();
+		$factory->setPaypalLogger( $logger );
 
-			$requestData = $this->newHttpParamsForPayment();
-			$requestData['mc_currency'] = 'unsupportedCurrencyTM';
-			$requestData['payer_email'] = 'IshouldNotGetLogged@privatestuff.de';
-			$requestData['payer_id'] = '123456personalID';
+		$requestData = $this->newHttpParamsForPayment();
+		$requestData['mc_currency'] = 'unsupportedCurrencyTM';
+		$requestData['payer_email'] = 'IshouldNotGetLogged@privatestuff.de';
+		$requestData['payer_id'] = '123456personalID';
 
-			$client->request(
-				Request::METHOD_POST,
-				self::PATH,
-				$requestData
-			);
+		$client->request(
+			Request::METHOD_POST,
+			self::PATH,
+			$requestData
+		);
 
-			$this->assertSame( 'Unsupported currency', $client->getResponse()->getContent() );
+		$this->assertSame( 'Unsupported currency', $client->getResponse()->getContent() );
 
-			$this->assertSame(
-				[ 'Unsupported currency' ],
-				$logger->getLogCalls()->getMessages()
-			);
+		$this->assertSame(
+			[ 'Unsupported currency' ],
+			$logger->getLogCalls()->getMessages()
+		);
 
-			$loggedDataAsString = implode( $logger->getLogCalls()->getFirstCall()->getContext()['post_vars'] );
+		$loggedDataAsString = implode( $logger->getLogCalls()->getFirstCall()->getContext()['post_vars'] );
 
-			$this->assertStringNotContainsString( 'IshouldNotGetLogged@privatestuff.de', $loggedDataAsString );
-			$this->assertStringNotContainsString( '123456personalID', $loggedDataAsString );
-			$this->assertStringContainsString( 'unsupportedCurrencyTM', $loggedDataAsString );
-		} );
+		$this->assertStringNotContainsString( 'IshouldNotGetLogged@privatestuff.de', $loggedDataAsString );
+		$this->assertStringNotContainsString( '123456personalID', $loggedDataAsString );
+		$this->assertStringContainsString( 'unsupportedCurrencyTM', $loggedDataAsString );
 	}
 
 	public function testGivenFailingVerification_applicationReturnsError(): void {
-		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ): void {
-			$this->setSucceedingDonationTokenGenerator( $factory );
-			$factory->setVerificationServiceFactory(
-				new FailingVerificationServiceFactory( sprintf( PayPalVerificationService::ERROR_UNKNOWN, 'FAIL' ) )
-			);
-			$this->storedDonations()->newStoredIncompletePayPalDonation();
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$this->setSucceedingDonationTokenGenerator( $factory );
+		$factory->setVerificationServiceFactory(
+			new FailingVerificationServiceFactory( sprintf( PayPalVerificationService::ERROR_UNKNOWN, 'FAIL' ) )
+		);
+		$this->storedDonations()->newStoredIncompletePayPalDonation();
 
-			$client->request(
-				Request::METHOD_POST,
-				self::PATH,
-				$this->newHttpParamsForPayment()
-			);
+		$client->request(
+			Request::METHOD_POST,
+			self::PATH,
+			$this->newHttpParamsForPayment()
+		);
 
-			$this->assertSame( 'An error occurred while trying to confirm the sent data. PayPal response: FAIL', $client->getResponse()->getContent() );
-			$this->assertSame( 403, $client->getResponse()->getStatusCode() );
-		} );
+		$this->assertSame( 'An error occurred while trying to confirm the sent data. PayPal response: FAIL', $client->getResponse()->getContent() );
+		$this->assertSame( 403, $client->getResponse()->getStatusCode() );
 	}
 
 	public function testGivenUnsupportedCurrency_applicationReturnsError(): void {
-		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ): void {
-			$this->setSucceedingDonationTokenGenerator( $factory );
-			$factory->setVerificationServiceFactory(
-				new FailingVerificationServiceFactory( PayPalVerificationService::ERROR_UNSUPPORTED_CURRENCY )
-			);
-			$this->storedDonations()->newStoredIncompletePayPalDonation();
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$this->setSucceedingDonationTokenGenerator( $factory );
+		$factory->setVerificationServiceFactory(
+			new FailingVerificationServiceFactory( PayPalVerificationService::ERROR_UNSUPPORTED_CURRENCY )
+		);
+		$this->storedDonations()->newStoredIncompletePayPalDonation();
 
-			$requestData = $this->newHttpParamsForPayment();
-			$requestData['mc_currency'] = 'DOGE';
-			$client->request(
-				Request::METHOD_POST,
-				self::PATH,
-				$requestData
-			);
+		$requestData = $this->newHttpParamsForPayment();
+		$requestData['mc_currency'] = 'DOGE';
+		$client->request(
+			Request::METHOD_POST,
+			self::PATH,
+			$requestData
+		);
 
-			$this->assertSame( 'Unsupported currency', $client->getResponse()->getContent() );
-			$this->assertSame( 406, $client->getResponse()->getStatusCode() );
-		} );
+		$this->assertSame( 'Unsupported currency', $client->getResponse()->getContent() );
+		$this->assertSame( 406, $client->getResponse()->getStatusCode() );
 	}
 
 	public function testGivenTransactionTypeForSubscriptionChanges_requestDataIsLogged(): void {
-		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ): void {
-			$this->setSucceedingDonationTokenGenerator( $factory );
-			$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
-			$this->storedDonations()->newStoredIncompletePayPalDonation();
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$this->setSucceedingDonationTokenGenerator( $factory );
+		$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
+		$this->storedDonations()->newStoredIncompletePayPalDonation();
 
-			$logger = new LoggerSpy();
-			$factory->setPaypalLogger( $logger );
+		$logger = new LoggerSpy();
+		$factory->setPaypalLogger( $logger );
 
-			$client->request(
-				Request::METHOD_POST,
-				self::PATH,
-				$this->newSubscriptionModificationParams()
-			);
+		$client->request(
+			Request::METHOD_POST,
+			self::PATH,
+			$this->newSubscriptionModificationParams()
+		);
 
-			$this->assertSame( 200, $client->getResponse()->getStatusCode() );
+		$this->assertSame( 200, $client->getResponse()->getStatusCode() );
 
-			$this->assertSame(
-				[ 'PayPal request not handled' ],
-				$logger->getLogCalls()->getMessages()
-			);
+		$this->assertSame(
+			[ 'PayPal request not handled' ],
+			$logger->getLogCalls()->getMessages()
+		);
 
-			$this->assertSame(
-				'subscr_modify',
-				$logger->getLogCalls()->getFirstCall()->getContext()['post_vars']['txn_type']
-			);
-		} );
+		$this->assertSame(
+			'subscr_modify',
+			$logger->getLogCalls()->getFirstCall()->getContext()['post_vars']['txn_type']
+		);
 	}
 
 	private function newSubscriptionModificationParams(): array {
@@ -389,102 +388,102 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 	}
 
 	public function testDonationIsNotFound_createsNewAnonymousDonation(): void {
-		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ): void {
-			$this->setSucceedingDonationTokenGenerator( $factory );
-			$factory->setVerificationServiceFactory(
-				new FailingVerificationServiceFactory( 'Donation not found' )
-			);
-			$factory->setPayPalVerificationService( new SucceedingVerificationService() );
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$this->setSucceedingDonationTokenGenerator( $factory );
+		$factory->setVerificationServiceFactory(
+			new FailingVerificationServiceFactory( 'Donation not found' )
+		);
+		$factory->setPayPalVerificationService( new SucceedingVerificationService() );
 
-			$client->request(
-				Request::METHOD_POST,
-				self::PATH,
-				$this->newHttpParamsForPayment()
-			);
+		$client->request(
+			Request::METHOD_POST,
+			self::PATH,
+			$this->newHttpParamsForPayment()
+		);
 
-			$this->assertPayPalDataGotPersisted( $this->newHttpParamsForPayment() );
-			$this->assertSame( '', $client->getResponse()->getContent() );
-			$this->assertSame( 200, $client->getResponse()->getStatusCode() );
-		} );
+		$this->assertPayPalDataGotPersisted( $this->newHttpParamsForPayment() );
+		$this->assertSame( '', $client->getResponse()->getContent() );
+		$this->assertSame( 200, $client->getResponse()->getStatusCode() );
 	}
 
 	public function testDonationIsNotFound_andCreationFails_logsError(): void {
-		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ): void {
-			$this->setSucceedingDonationTokenGenerator( $factory );
-			$factory->setVerificationServiceFactory(
-				new FailingVerificationServiceFactory( 'Donation not found' )
-			);
-			$factory->setPayPalVerificationService( new FailingPayPalVerificationService( 'Awoo! Nyaa!' ) );
-			$logger = new LoggerSpy();
-			$factory->setPaypalLogger( $logger );
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$this->setSucceedingDonationTokenGenerator( $factory );
+		$factory->setVerificationServiceFactory(
+			new FailingVerificationServiceFactory( 'Donation not found' )
+		);
+		$factory->setPayPalVerificationService( new FailingPayPalVerificationService( 'Awoo! Nyaa!' ) );
+		$logger = new LoggerSpy();
+		$factory->setPaypalLogger( $logger );
 
-			$client->request(
-				Request::METHOD_POST,
-				self::PATH,
-				$this->newHttpParamsForPayment()
-			);
+		$client->request(
+			Request::METHOD_POST,
+			self::PATH,
+			$this->newHttpParamsForPayment()
+		);
 
-			$this->assertSame(
-				[ 'Awoo! Nyaa!' ],
-				$logger->getLogCalls()->getMessages()
-			);
-		} );
+		$this->assertSame(
+			[ 'Awoo! Nyaa!' ],
+			$logger->getLogCalls()->getMessages()
+		);
 	}
 
 	public function testOnInternalError_applicationIndicatesError(): void {
-		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ): void {
-			$this->setSucceedingDonationTokenGenerator( $factory );
-			$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$this->setSucceedingDonationTokenGenerator( $factory );
+		$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
 
-			$repository = new ThrowingDonationRepository();
-			$repository->throwOnGetDonationById();
-			$factory->setDonationRepository( $repository );
+		$repository = new ThrowingDonationRepository();
+		$repository->throwOnGetDonationById();
+		$factory->setDonationRepository( $repository );
 
-			$this->storedDonations()->newStoredIncompletePayPalDonation();
+		$this->storedDonations()->newStoredIncompletePayPalDonation();
 
-			$client->request(
-				Request::METHOD_POST,
-				self::PATH,
-				$this->newHttpParamsForPayment()
-			);
+		$client->request(
+			Request::METHOD_POST,
+			self::PATH,
+			$this->newHttpParamsForPayment()
+		);
 
-			$this->assertSame( 500, $client->getResponse()->getStatusCode() );
-			$this->assertStringContainsString( "Could not get donation", $client->getResponse()->getContent() );
-		} );
+		$this->assertSame( 500, $client->getResponse()->getStatusCode() );
+		$this->assertStringContainsString( "Could not get donation", $client->getResponse()->getContent() );
 	}
 
 	public function testOnInternalError_applicationLogsError(): void {
-		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ): void {
-			$this->setSucceedingDonationTokenGenerator( $factory );
-			$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$this->setSucceedingDonationTokenGenerator( $factory );
+		$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
 
-			$repository = new ThrowingDonationRepository();
-			$repository->throwOnGetDonationById();
-			$factory->setDonationRepository( $repository );
+		$repository = new ThrowingDonationRepository();
+		$repository->throwOnGetDonationById();
+		$factory->setDonationRepository( $repository );
 
-			$paypalLogger = new LoggerSpy();
-			$mainErrorLogger = new LoggerSpy();
+		$paypalLogger = new LoggerSpy();
+		$mainErrorLogger = new LoggerSpy();
 
-			$factory->setPaypalLogger( $paypalLogger );
-			$factory->setLogger( $mainErrorLogger );
+		$factory->setPaypalLogger( $paypalLogger );
+		$factory->setLogger( $mainErrorLogger );
 
-			$this->storedDonations()->newStoredIncompletePayPalDonation();
+		$this->storedDonations()->newStoredIncompletePayPalDonation();
 
-			$client->request(
-				Request::METHOD_POST,
-				self::PATH,
-				$this->newHttpParamsForPayment()
-			);
+		$client->request(
+			Request::METHOD_POST,
+			self::PATH,
+			$this->newHttpParamsForPayment()
+		);
 
-			$this->assertSame( 1, $paypalLogger->getLogCalls()->count() );
-			$firstCallContext = $paypalLogger->getFirstLogCall()->getContext();
-			$this->assertArrayHasKey( 'stacktrace', $firstCallContext );
-			$this->assertArrayHasKey( 'post_vars', $firstCallContext );
-			$this->assertSame( 'An Exception happened: Could not get donation', $paypalLogger->getFirstLogCall()->getMessage() );
+		$this->assertSame( 1, $paypalLogger->getLogCalls()->count() );
+		$firstCallContext = $paypalLogger->getFirstLogCall()->getContext();
+		$this->assertArrayHasKey( 'stacktrace', $firstCallContext );
+		$this->assertArrayHasKey( 'post_vars', $firstCallContext );
+		$this->assertSame( 'An Exception happened: Could not get donation', $paypalLogger->getFirstLogCall()->getMessage() );
 
-			$this->assertSame( 1, $mainErrorLogger->getLogCalls()->count() );
-			$this->assertSame( 'An Exception happened: Could not get donation', $mainErrorLogger->getFirstLogCall()->getMessage() );
-		} );
+		$this->assertSame( 1, $mainErrorLogger->getLogCalls()->count() );
+		$this->assertSame( 'An Exception happened: Could not get donation', $mainErrorLogger->getFirstLogCall()->getMessage() );
 	}
 
 	private function newValidRequestParametersWithNegativeTransactionFee(): array {

--- a/tests/EdgeToEdge/Routes/SofortPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/SofortPaymentNotificationRouteTest.php
@@ -204,7 +204,7 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 			);
 
 			$this->assertIsBadRequestResponse( $client->getResponse() );
-			$this->assertErrorCauseIsLogged( $logger, 'Payment is already completed' );
+			$this->assertErrorCauseIsLogged( $logger, 'Payment was booked before' );
 			$this->assertRequestVarsAreLogged( $logger );
 			$this->assertLogLevel( $logger, LogLevel::ERROR );
 		} );

--- a/tests/Fixtures/StoredDonations.php
+++ b/tests/Fixtures/StoredDonations.php
@@ -47,6 +47,11 @@ class StoredDonations {
 		return $this->persistDonation( ValidDonation::newIncompletePayPalDonation() );
 	}
 
+	public function newStoredCompletePayPalDonation(): Donation {
+		$this->persistPayment( ValidPayments::newBookedPayPalPayment() );
+		return $this->persistDonation( ValidDonation::newBookedPayPalDonation() );
+	}
+
 	public function newStoredDirectDebitDonation(): Donation {
 		$payment = ValidPayments::newDirectDebitPayment();
 		$this->persistPayment( $payment );


### PR DESCRIPTION
Check booking response if the failure reason is that the payment was
already booked. We still log the error (as a warning), but no longer
return an error response, because PayPal would try to book the
already-booked payment again several times.

Check success response for empty body in the tests.

Ticket:  https://phabricator.wikimedia.org/T321346