### PR TITLE
Prepare address preselection bucket test

### DIFF
--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -24,13 +24,13 @@ campaigns:
 
 
     address_type_steps:
-      description: Test Donating with E-Mail only
-      reference: "https://phabricator.wikimedia.org/T322415"
-      start: "2022-11-07"
+      description: Test Donating with address preselection, allowing for E-Mail only and anonymous
+      reference: "https://phabricator.wikimedia.org/T323931"
+      start: "2022-12-07"
       end: "2022-12-31"
       buckets:
         - "direct"
-        - "require_address"
+        - "preselect"
       default_bucket: "direct"
       url_key: ast
       active: true


### PR DESCRIPTION
Change configuration for Test T323931 that
1) shows anonymous (as opposed to the previous test T322415 that did not
   show that)
2) Applies the address type value that was preselected from the banner.
   This is why the 2nd option is called "preselect".

https://phabricator.wikimedia.org/T323938