### PR TITLE
Set start date of bucket test earlier

### DIFF
--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -26,7 +26,7 @@ campaigns:
     address_type_steps:
       description: Test Donating with address preselection, allowing for E-Mail only and anonymous
       reference: "https://phabricator.wikimedia.org/T323931"
-      start: "2022-12-07"
+      start: "2022-12-05"
       end: "2022-12-31"
       buckets:
         - "direct"


### PR DESCRIPTION
The test should start today, setting it two days earlier

Ticket: https://phabricator.wikimedia.org/T323931
