### PR TITLE
Add email or full address select to ast test

### DIFF
--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -31,6 +31,7 @@ campaigns:
       buckets:
         - "direct"
         - "preselect"
+        - "full_or_email"
       default_bucket: "direct"
       url_key: ast
       active: true


### PR DESCRIPTION
This adds a third option to the address type selector to allow a selection of full or email only addresses

Ticket: https://phabricator.wikimedia.org/T325877