### PR TITLE
Check transaction type of PayPal notifications

### DIFF
--- a/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
@@ -129,7 +129,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 			'custom' => '{"sid": 1, "utoken": "my_secret_token"}',
 			'txn_id' => '61E67681CH3238416',
 			'payment_type' => 'instant',
-			'txn_type' => 'express_checkout',
+			'txn_type' => 'web_accept',
 			'payment_date' => '20:12:59 Jan 13, 2009 PST',
 		];
 	}


### PR DESCRIPTION
Check the transaction type of Instant Payment Notifications from PayPal. The previous code just checked the type for recurring payments and relied on the status for all other types. This led to errors (e.g. "Completed" refunds misidentified as payments).

The new, strict payment types are derived from actual data in the database (see [this comment](https://phabricator.wikimedia.org/T315701#8490701))

Ticket: https://phabricator.wikimedia.org/T315701