### PR TITLE
Add new mailer for updated donations

### DIFF
--- a/src/Infrastructure/Mail/NullMailer.php
+++ b/src/Infrastructure/Mail/NullMailer.php
@@ -1,0 +1,15 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure\Mail;
+
+use WMDE\EmailAddress\EmailAddress;
+use WMDE\Fundraising\DonationContext\Infrastructure\TemplateMailerInterface;
+
+class NullMailer implements TemplateMailerInterface {
+
+	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ): void {
+		// Does nothing on purpose
+	}
+}


### PR DESCRIPTION
This uses the new donations template with a new
subject line for updated donation mails.

As donations can now be updated multiple times we
no longer want to send admins a moderation email
each time one is changed.

Ticket: https://phabricator.wikimedia.org/T317641