### PR TITLE
Remove legacy Doctrine initialization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"wmde/fundraising-donations": "~13.0",
 		"wmde/fundraising-memberships": "~11.1",
 		"wmde/fundraising-payments": "~5.0",
-		"wmde/fundraising-subscriptions": "~3.1",
+		"wmde/fundraising-subscriptions": "~4.0",
 		"wmde/fundraising-content-provider": "~6.0",
 		"wmde/fundraising-address-change": "~2.0",
 		"wmde/freezable-value-object": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d965387ec8fe24b58b0a5766e364509d",
+    "content-hash": "32c835c555d0769632af4c6e70af11d6",
     "packages": [
         {
             "name": "airbrake/phpbrake",
@@ -1798,16 +1798,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.4.3",
+            "version": "2.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "67c26b443f348a51926030c83481b85718457d3d"
+                "reference": "3cf1b6d4f0c820a2cf8bcaec39fc698f3443b5cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/67c26b443f348a51926030c83481b85718457d3d",
-                "reference": "67c26b443f348a51926030c83481b85718457d3d",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/3cf1b6d4f0c820a2cf8bcaec39fc698f3443b5cf",
+                "reference": "3cf1b6d4f0c820a2cf8bcaec39fc698f3443b5cf",
                 "shasum": ""
             },
             "require": {
@@ -1897,7 +1897,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.4.3"
+                "source": "https://github.com/guzzle/psr7/tree/2.4.4"
             },
             "funding": [
                 {
@@ -1913,7 +1913,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-26T14:07:24+00:00"
+            "time": "2023-03-09T13:19:02+00:00"
         },
         {
             "name": "jeroen/file-fetcher",
@@ -7171,29 +7171,29 @@
         },
         {
             "name": "wmde/fundraising-subscriptions",
-            "version": "v3.1.0",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-subscriptions",
-                "reference": "3b88ab04442a1cd5c950f9ce218f2631e140c744"
+                "reference": "2d82508efa0c26cd3f0c3c381cbd143c1bc09c60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-subscriptions/zipball/3b88ab04442a1cd5c950f9ce218f2631e140c744",
-                "reference": "3b88ab04442a1cd5c950f9ce218f2631e140c744",
+                "url": "https://api.github.com/repos/wmde/fundraising-subscriptions/zipball/2d82508efa0c26cd3f0c3c381cbd143c1bc09c60",
+                "reference": "2d82508efa0c26cd3f0c3c381cbd143c1bc09c60",
                 "shasum": ""
             },
             "require": {
                 "doctrine/orm": "~2.7",
                 "gedmo/doctrine-extensions": "^3.0",
-                "php": ">=8.0",
+                "php": ">=8.1",
                 "psr/log": "^1.0|^2.0|^3.0",
                 "wmde/email-address": "~1.0",
                 "wmde/fun-validators": "~4.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "~1.7",
-                "phpunit/phpunit": "~9.5.1",
+                "phpunit/phpunit": "~10.0.7",
                 "symfony/cache": "^5.3",
                 "wmde/fundraising-phpcs": "~7.0"
             },
@@ -7217,7 +7217,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Bounded Context for fundraising subcriptions",
-            "time": "2022-05-30T08:03:04+00:00"
+            "time": "2023-02-14T16:01:41+00:00"
         }
     ],
     "packages-dev": [
@@ -8434,16 +8434,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.0.15",
+            "version": "10.0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9b0c2245ef173a3d9546f6a4393a85d60eabe071"
+                "reference": "07d386a11ac7094032900f07cada1c8975d16607"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9b0c2245ef173a3d9546f6a4393a85d60eabe071",
-                "reference": "9b0c2245ef173a3d9546f6a4393a85d60eabe071",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/07d386a11ac7094032900f07cada1c8975d16607",
+                "reference": "07d386a11ac7094032900f07cada1c8975d16607",
                 "shasum": ""
             },
             "require": {
@@ -8514,7 +8514,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.15"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.16"
             },
             "funding": [
                 {
@@ -8530,7 +8530,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-09T06:43:13+00:00"
+            "time": "2023-03-13T09:02:40+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -9759,12 +9759,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-frontend-content",
-                "reference": "cb96ae61ae128b043c985077c4587e1de18d30fa"
+                "reference": "a667cc4cae4d52e1ed7145827f4bc6500c0a8fbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/cb96ae61ae128b043c985077c4587e1de18d30fa",
-                "reference": "cb96ae61ae128b043c985077c4587e1de18d30fa",
+                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/a667cc4cae4d52e1ed7145827f4bc6500c0a8fbc",
+                "reference": "a667cc4cae4d52e1ed7145827f4bc6500c0a8fbc",
                 "shasum": ""
             },
             "require": {
@@ -9808,7 +9808,7 @@
                 "CC0-1.0"
             ],
             "description": "i18n for FundraisingFrontend",
-            "time": "2023-02-20T12:47:34+00:00"
+            "time": "2023-03-13T09:52:11+00:00"
         },
         {
             "name": "wmde/fundraising-phpcs",


### PR DESCRIPTION
Use new versions of subscription and address change bounded context. This allows to remove all legacy Doctrine initialization code.

Ticket: https://phabricator.wikimedia.org/T312080