### PR TITLE
Update email configuration

### DIFF
--- a/.docker/app/config.dev.json
+++ b/.docker/app/config.dev.json
@@ -35,13 +35,25 @@
   },
   "i18n-base-path": "vendor/wmde/fundraising-frontend-content/i18n",
   "contact-info": {
-    "organization": {
+    "donation": {
+      "email": "spenden@wikimedia.de",
+      "name": "Wikimedia Deutschland e. V."
+    },
+    "membership": {
       "email": "mitglieder@wikimedia.de",
       "name": "Wikimedia Deutschland e. V."
     },
-    "suborganization": {
+    "subscription": {
       "email": "spenden@wikimedia.de",
-      "name": "Wikimedia Fördergesellschaft mbH"
+      "name": "Wikimedia Deutschland e. V."
+    },
+    "contact": {
+      "email": "spenden@wikimedia.de",
+      "name": "Wikimedia Deutschland e. V."
+    },
+    "admin": {
+      "email": "spenden@wikimedia.de",
+      "name": "Wikimedia Deutschland e. V."
     }
   },
   "donation-timeframe-limit": "PT1S",

--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -22,11 +22,23 @@
 	},
 	"i18n-base-path": "",
 	"contact-info": {
-		"organization": {
+		"donation": {
 			"email": "",
 			"name": ""
 		},
-		"suborganization": {
+		"membership": {
+			"email": "",
+			"name": ""
+		},
+		"subscription": {
+			"email": "",
+			"name": ""
+		},
+		"contact": {
+			"email": "",
+			"name": ""
+		},
+		"admin": {
 			"email": "",
 			"name": ""
 		}

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -21,13 +21,25 @@
 	"donation-timeframe-limit": "PT30M",
 	"membership-application-timeframe-limit": "PT10M",
 	"contact-info": {
-		"organization": {
-			"email": "email@operatorsownmailserver.com",
-			"name": "Friendly Operator"
+		"donation": {
+			"email": "donation@operatorsownmailserver.com",
+			"name": "Donation Operator"
 		},
-		"suborganization": {
-			"email": "sub.email@operatorsownmailserver.com",
-			"name": "Alternative Operator"
+		"membership": {
+			"email": "membership@operatorsownmailserver.com",
+			"name": "Membership Operator"
+		},
+		"subscription": {
+			"email": "subscription@operatorsownmailserver.com",
+			"name": "Subscription Operator"
+		},
+		"contact": {
+			"email": "contact@operatorsownmailserver.com",
+			"name": "Contact Operator"
+		},
+		"admin": {
+			"email": "admin@operatorsownmailserver.com",
+			"name": "Admin Operator"
 		}
 	},
 	"paypal-donation": {

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -184,10 +184,10 @@
       "title": "Contact information",
       "description": "Names and email addresses for creating email recipients and senders",
       "properties": {
-        "organization": {
+        "donation": {
           "type": "object",
-          "title": "Main Organization",
-          "description": "Main sender of email address. In case of WikiMedia Germany, this is mostly for memberships",
+          "title": "Donation Emails",
+          "description": "Emails to donors are sent from this address",
           "properties": {
             "email": {
               "type": "string",
@@ -203,10 +203,67 @@
           },
           "required": [ "name", "email" ]
         },
-        "suborganization": {
+        "membership": {
           "type": "object",
-          "title": "Sub-Organization",
-          "description": "Sender of email address. In case of WikiMedia Germany, this is for donations and subscriptions'",
+          "title": "Membership Emails",
+          "description": "Emails to members are sent from this address",
+          "properties": {
+            "email": {
+              "type": "string",
+              "minLength": 1,
+              "default": "",
+              "format": "email"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "default": ""
+            }
+          },
+          "required": [ "name", "email" ]
+        },
+        "subscription": {
+          "type": "object",
+          "title": "Subscription Validation and Confirmation Emails",
+          "description": "Emails to mail subscribers are sent from here",
+          "properties": {
+            "email": {
+              "type": "string",
+              "minLength": 1,
+              "default": "",
+              "format": "email"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "default": ""
+            }
+          },
+          "required": [ "name", "email" ]
+        },
+        "contact": {
+          "type": "object",
+          "title": "Contact Emails",
+          "description": "Emails to people who fill out the contact form are sent from here",
+          "properties": {
+            "email": {
+              "type": "string",
+              "minLength": 1,
+              "default": "",
+              "format": "email"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "default": ""
+            }
+          },
+          "required": [ "name", "email" ]
+        },
+        "admin": {
+          "type": "object",
+          "title": "The Admin email address",
+          "description": "Admin emails are sent to this address",
           "properties": {
             "email": {
               "type": "string",

--- a/tests/EdgeToEdge/Routes/GetInTouchRouteTest.php
+++ b/tests/EdgeToEdge/Routes/GetInTouchRouteTest.php
@@ -90,7 +90,7 @@ class GetInTouchRouteTest extends WebRouteTestCase {
 				->method( 'sendMessageToUser' )
 				->willThrowException( new \RuntimeException( 'Something unexpected happened' ) );
 
-			$factory->setOrganizationMessenger( $messenger );
+			$factory->setContactMessenger( $messenger );
 		} );
 		$client = $this->createClient();
 

--- a/tests/TestEnvironmentSetup.php
+++ b/tests/TestEnvironmentSetup.php
@@ -16,7 +16,7 @@ use WMDE\Fundraising\Frontend\Tests\Fixtures\FeatureReaderStub;
  */
 class TestEnvironmentSetup implements EnvironmentSetup {
 	public function setEnvironmentDependentInstances( FunFunFactory $factory ): void {
-		$factory->setNullMessenger();
+		$factory->setNullMessengers();
 		$factory->setDomainNameValidator( new NullDomainNameValidator() );
 		$factory->setDoctrineConfiguration( ORMSetup::createXMLMetadataConfiguration( $factory->getDoctrineXMLMappingPaths(), true ) );
 		$factory->setInternalErrorHtmlPresenter( new DevelopmentInternalErrorHtmlPresenter() );


### PR DESCRIPTION
Emails used to be sent by either the organisation
or sub-organisation. Now that the sub-organisation is gone the senders can be split to make the sender details for each type of email the users receive
explicit.

Ticket: https://phabricator.wikimedia.org/T342843#9055444