### PR TITLE
Set http_method_override in config

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -2,7 +2,7 @@
 framework:
     secret: '%env(APP_SECRET)%'
     #csrf_protection: true
-    #http_method_override: true
+    http_method_override: false
 
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.


### PR DESCRIPTION
In Symfony 7.0 http_method_override will be a required value. This
change removes deprecation warnings we are getting in environments
where APP_DEBUG=0

Setting it to `false` will forbid the trick of passing a `_method`
parameter to in the URL to override the HTTP method. We don't use this
in the frontend code and can safely disable it.
