### PR TITLE
Make the bucket test campaign start earlier

### DIFF
--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -26,7 +26,7 @@ campaigns:
     address_type_steps:
       description: Test different kinds of address options, ask user whether they want receipt or just confirmation
       reference: "https://phabricator.wikimedia.org/T342206"
-      start: "2023-08-10"
+      start: "2023-08-08" # Banners start at 2023-08-10, earlier date is for testing the banners
       end: "2023-12-31"
       buckets:
         - "direct"


### PR DESCRIPTION
so the campaigns team can test the banners in the production
environment. While this allows inquisitive users to see the form
"early", there is no harm in that.

This is for https://phabricator.wikimedia.org/T342206
