### PR TITLE
Append bucket testing parameters to redirect URLs

### DIFF
--- a/app/EventHandlers/AppendBucketParametersForRedirect.php
+++ b/app/EventHandlers/AppendBucketParametersForRedirect.php
@@ -1,0 +1,63 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\App\EventHandlers;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
+
+/**
+ * This event modifies redirect responses and adds the bucket parameters to the URL.
+ * This allows us to do bucket tests without storing anything on the client side.
+ */
+class AppendBucketParametersForRedirect implements EventSubscriberInterface {
+
+	public function __construct( private readonly FunFunFactory $factory ) {
+	}
+
+	/**
+	 * @return array<string, array{string, int}>
+	 */
+	public static function getSubscribedEvents(): array {
+		return [
+			KernelEvents::RESPONSE => 'appendBucketParameters',
+		];
+	}
+
+	public function appendBucketParameters( ResponseEvent $event ): void {
+		$response = $event->getResponse();
+		if ( !$response->isRedirect() ) {
+			return;
+		}
+
+		$location = $response->headers->get( 'Location', '' );
+
+		if ( $this->locationIsApplicationUrl( $location, $event->getRequest() ) ) {
+			return;
+		}
+
+		$response->headers->set(
+			'Location',
+			$location . $this->getUrlParameters( $location )
+		);
+	}
+
+	private function locationIsApplicationUrl( ?string $location, Request $request ): bool {
+		return !str_starts_with( $location, $request->getSchemeAndHttpHost() ) ||
+			// The standard says 'Location' header should be absolute, but we can't be sure
+			str_starts_with( $location, '/' );
+	}
+
+	private function getUrlParameters( string $location ): string {
+		$params = [];
+		foreach ( $this->factory->getSelectedBuckets() as $bucket ) {
+			$params = array_merge( $params, $bucket->getParameters() );
+		}
+
+		$separator = !str_contains( $location, '?' ) ? '?' : '&';
+		return $separator . http_build_query( $params );
+	}
+}

--- a/app/config/campaigns.test.yml
+++ b/app/config/campaigns.test.yml
@@ -1,0 +1,24 @@
+# Configuration file for the test environment
+# Defines a fictional A/B test
+
+# You can also override start and end date of the regular campaigns here,
+# to test them before they go live
+
+campaigns:
+
+  show_unicorns:
+    description: >
+      Show pink fluffy unicorns dancing on rainbows to select donors.
+      
+      This campaign is used for testing the parameter passing on redirects
+      See AddDonationRouteTest.
+    start: "2023-08-08"
+    end: "2038-01-18"
+    buckets:
+      - "default"
+      - "fluffy"
+      - "pink"
+    default_bucket: "default"
+    url_key: pfu
+    active: true
+    param_only: true

--- a/src/BucketTesting/BucketSelector.php
+++ b/src/BucketTesting/BucketSelector.php
@@ -29,6 +29,10 @@ class BucketSelector {
 		return $sanitized;
 	}
 
+	/**
+	 * @param array $urlParameters
+	 * @return Bucket[]
+	 */
 	public function selectBuckets( array $urlParameters = [] ): array {
 		$possibleParameters = $this->sanitizeParameters( $urlParameters );
 

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1770,6 +1770,9 @@ class FunFunFactory implements LoggerAwareInterface {
 		$this->sharedObjects['bucketLogger'] = $logger;
 	}
 
+	/**
+	 * @return Bucket[]
+	 */
 	public function getSelectedBuckets(): array {
 		// when in the web environment, selected buckets will be set by BucketSelectionServiceProvider during request processing
 		// other environments (testing/cli) may set this during setup
@@ -1779,6 +1782,9 @@ class FunFunFactory implements LoggerAwareInterface {
 		return $this->sharedObjects['selectedBuckets'];
 	}
 
+	/**
+	 * @param Bucket[] $selectedBuckets
+	 */
 	public function setSelectedBuckets( array $selectedBuckets ): void {
 		$this->sharedObjects['selectedBuckets'] = $selectedBuckets;
 	}

--- a/tests/EdgeToEdge/Routes/UpdateDonorRouteTest.php
+++ b/tests/EdgeToEdge/Routes/UpdateDonorRouteTest.php
@@ -45,7 +45,11 @@ class UpdateDonorRouteTest extends WebRouteTestCase {
 			self::CORRECT_UPDATE_TOKEN
 		);
 		$response = $client->getResponse();
-		$this->assertTrue( $response->isRedirect( $this->newValidSuccessRedirectUrl( $donation, $factory ) ) );
+		$this->assertTrue( $response->isRedirect() );
+		$this->assertStringStartsWith(
+			$this->newValidSuccessRedirectUrl( $donation, $factory ),
+			$response->headers->get( 'Location' )
+		);
 
 		$crawler = $client->followRedirect();
 		$dataVars = $this->getDataApplicationVars( $crawler );
@@ -76,7 +80,11 @@ class UpdateDonorRouteTest extends WebRouteTestCase {
 		);
 
 		$response = $client->getResponse();
-		$this->assertTrue( $response->isRedirect( $this->newValidSuccessRedirectUrl( $donation, $factory ) ) );
+		$this->assertTrue( $response->isRedirect() );
+		$this->assertStringStartsWith(
+			$this->newValidSuccessRedirectUrl( $donation, $factory ),
+			$response->headers->get( 'Location' )
+		);
 
 		$crawler = $client->followRedirect();
 		$dataVars = $this->getDataApplicationVars( $crawler );


### PR DESCRIPTION
Add an HTTP response event handler that appends the bucket testing
parameters to all redirect URLs that lead to other routes in the
Fundraising Application. This preserves the bucket selection between
pages, without resorting to a PHP session or client-side storage, both
of which would require user consent.

This change is important for banner test C23_WMDE_Desktop_DE_06 (tracked
in ticket [T345721](https://phabricator.wikimedia.org/T345721)), but is
useful for all subsequent tests.

This change does NOT add the parameters to the confirmation page for
external payments - we'd have to expose the URL generation for payment
providers to the app via interface/events. With the changes coming in
the PayPal API implementation tickets (see [parent ticket
T329159](https://phabricator.wikimedia.org/T329159) ) it would be
duplicated and increased effort to do it now.

Ticket: https://phabricator.wikimedia.org/T347008
