### PR TITLE
Validate default development config

### DIFF
--- a/.docker/app/config.dev.json
+++ b/.docker/app/config.dev.json
@@ -61,7 +61,7 @@
   "purging-secret": "purgeme",
   "paypal-donation": {
     "base-url": "https://www.sandbox.paypal.com/cgi-bin/webscr?",
-    "account-address": "PAYPAL_USERNAME_IS_MISSING",
+    "account-address": "INSERT_CORRECT_USERNAME_HERE@wikimedia.de",
     "notify-url": "http://localhost:8082/handle-paypal-payment-notification",
     "return-url": "http://localhost:8082/show-donation-confirmation",
     "cancel-url": "http://localhost:8082/",
@@ -69,7 +69,7 @@
   },
   "paypal-membership": {
     "base-url": "https://www.sandbox.paypal.com/cgi-bin/webscr?",
-    "account-address": "PAYPAL_USERNAME_IS_MISSING",
+    "account-address": "INSERT_CORRECT_USERNAME_HERE@wikimedia.de",
     "notify-url": "http://localhost:8082/handle-paypal-membership-fee-notification",
     "return-url": "http://localhost:8082/show-membership-confirmation",
     "cancel-url": "http://localhost:8082/",

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ lint-container:
 
 validate-app-config:
 	docker-compose run --rm --no-deps app ./bin/console app:validate:config app/config/config.dist.json app/config/config.test.json
+	docker-compose run --rm --no-deps app ./bin/console app:validate:config app/config/config.dist.json .docker/app/config.dev.json
 
 validate-campaign-config:
 	docker-compose run --rm --no-deps app ./bin/console app:validate:campaigns $(APP_ENV)

--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -106,8 +106,7 @@
 		"baseUrl": "//tracking.wikimedia.de/",
 		"siteId": 5,
 		"donationConfirmationGoalId": 1,
-		"membershipApplicationConfirmationGoalId": 2,
-		"siteUrlBase": ""
+		"membershipApplicationConfirmationGoalId": 2
 	},
 	"payment-types": {
 		"BEZ": {

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -79,8 +79,7 @@
 		"baseUrl": "//tracking.wikimedia.de/",
 		"siteId": 1234,
 		"donationConfirmationGoalId": 1,
-		"membershipApplicationConfirmationGoalId": 2,
-		"siteUrlBase": "http://test-spenden.wikimedia.local"
+		"membershipApplicationConfirmationGoalId": 2
 	},
 	"purging-secret": "Not so secret, testing",
 	"i18n-base-path": "vendor/wmde/fundraising-frontend-content/i18n",

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -681,12 +681,12 @@
     },
     "piwik": {
       "type": "object",
-      "title": "Piwik settings",
+      "title": "Matomo (formerly Piwik) settings",
       "properties": {
         "baseUrl": {
           "type": "string",
           "title": "Tracker URL",
-          "description": "Base URL for the Piwik installation. Make sure it starts with //, not with http:// or https://, that way the browser will automatically select the right transport when the URL is printed in a template",
+          "description": "Base URL for the Matomo installation. Make sure it starts with //, not with http:// or https://, that way the browser will automatically select the right transport when the URL is printed in a template",
           "format": "url",
           "default": "//tracking.wikimedia.de/",
           "pattern": "^(\\/){2}[a-zA-Z0-9.\\/]+$"
@@ -694,27 +694,20 @@
         "siteId": {
           "type": "integer",
           "title": "Site ID",
-          "description": "Unique site id (configured in Piwik)",
+          "description": "Unique site id (configured in Matomo)",
           "default": 1
         },
         "donationConfirmationGoalId": {
           "type": "integer",
           "title": "Donation Confirmation Goal ID",
-          "description": "Unique id (configured in Piwik)",
+          "description": "Unique id (configured in Matomo)",
           "default": 1
         },
         "membershipApplicationConfirmationGoalId": {
           "type": "integer",
           "title": "Membership Application Confirmation Goal ID",
-          "description": "Unique id (configured in Piwik)",
+          "description": "Unique id (configured in Matomo)",
           "default": 2
-        },
-        "siteUrlBase": {
-          "type": "string",
-          "title": "Site url",
-          "description": "Base URL for server-side piwik tracking. It must *not* have a slash at the end",
-          "format": "url",
-          "minLength": 1
         }
       },
       "additionalProperties": false,
@@ -722,8 +715,7 @@
         "baseUrl",
         "siteId",
         "donationConfirmationGoalId",
-        "membershipApplicationConfirmationGoalId",
-        "siteUrlBase"
+        "membershipApplicationConfirmationGoalId"
       ]
     },
     "payment-types": {


### PR DESCRIPTION
To avoid a broken out-of-the-box configuration, validate the default
development configuration in `.docker/app/config.dev.json` (copied to
`app/config` by the `make default-config` task). This will remind us to
change both the default configuration and the test configuration
whenever we make changes to the configuration schema in
`app/config/schema.json`.

Remove the siteUrlBase property from the required Matomo configuration
settings - it was used for the server-side tracking, which was removed
in Nov 2020 with commit f28cfd90f97ec4d971f247e8af42d3c7d5642309

Rename "Piwik" to "Matomo", at least in the item descriptions.

This is a change that'll affect deployment, please adapt the
configuration files in the infrastructure repository
