### PR TITLE
Change donation comment post param names

### DIFF
--- a/app/Controllers/Donation/AddCommentController.php
+++ b/app/Controllers/Donation/AddCommentController.php
@@ -44,13 +44,13 @@ class AddCommentController {
 	private function buildAddCommentRequest( ParameterBag $postVars ): AddCommentRequest {
 		$addCommentRequest = new AddCommentRequest();
 		$addCommentRequest->setCommentText( trim( $postVars->get( 'comment', '' ) ) );
-		$addCommentRequest->setIsPublic( $postVars->getBoolean( 'public' ) );
+		$addCommentRequest->setIsPublic( $postVars->getBoolean( 'isPublic' ) );
 		$addCommentRequest->setDonationId( (int)$postVars->get( 'donationId', '' ) );
 
-		if ( $postVars->getBoolean( 'isAnonymous' ) ) {
-			$addCommentRequest->setIsAnonymous();
-		} else {
+		if ( $postVars->getBoolean( 'withName' ) ) {
 			$addCommentRequest->setIsNamed();
+		} else {
+			$addCommentRequest->setIsAnonymous();
 		}
 
 		$addCommentRequest->freeze()->assertNoNullFields();

--- a/tests/EdgeToEdge/Routes/AddCommentPostRouteTest.php
+++ b/tests/EdgeToEdge/Routes/AddCommentPostRouteTest.php
@@ -44,8 +44,8 @@ class AddCommentPostRouteTest extends WebRouteTestCase {
 			self::PATH,
 			[
 				'comment' => 'Take my money!',
-				'public' => '1',
-				'isAnonymous' => '0',
+				'isPublic' => '1',
+				'withName' => '1',
 				'donationId' => (string)$donation->getId(),
 			]
 		);
@@ -64,8 +64,8 @@ class AddCommentPostRouteTest extends WebRouteTestCase {
 			self::PATH,
 			[
 				'comment' => 'Take my money!',
-				'public' => '1',
-				'isAnonymous' => '0',
+				'isPublic' => '1',
+				'withName' => '1',
 				'donationId' => (string)$donation->getId(),
 				'updateToken' => self::CORRECT_UPDATE_TOKEN,
 			]
@@ -84,8 +84,8 @@ class AddCommentPostRouteTest extends WebRouteTestCase {
 			self::PATH,
 			[
 				'comment' => 'Take my money!',
-				'public' => '1',
-				'isAnonymous' => '0',
+				'isPublic' => '1',
+				'withName' => '1',
 				'donationId' => self::NON_EXISTING_DONATION_ID,
 				'updateToken' => self::CORRECT_UPDATE_TOKEN,
 			]
@@ -105,8 +105,8 @@ class AddCommentPostRouteTest extends WebRouteTestCase {
 			self::PATH,
 			[
 				'comment' => 'Take my money!',
-				'public' => '1',
-				'isAnonymous' => '0',
+				'isPublic' => '1',
+				'withName' => '1',
 				'donationId' => (string)$donation->getId(),
 				'updateToken' => 'Not the correct token',
 			]
@@ -126,8 +126,8 @@ class AddCommentPostRouteTest extends WebRouteTestCase {
 			self::PATH,
 			[
 				'comment' => 'Gotta make dat 💲',
-				'public' => '1',
-				'isAnonymous' => '0',
+				'isPublic' => '1',
+				'withName' => '1',
 				'donationId' => (string)$donation->getId(),
 				'updateToken' => self::CORRECT_UPDATE_TOKEN,
 			]


### PR DESCRIPTION
The isAnonymous field in the front end was passing 1 when the checkbox was not checked. I Renamed it to withName and now pass a 1 when the checkbox is checked.

Renames the public field to isPublic to prevent any possible reserved name issues.

Ticket: https://phabricator.wikimedia.org/T349161

Should only be deployed when https://github.com/wmde/fundraising-app-frontend/pull/231 is merged.