### PR TITLE
Avoid Doctrine deprecation warning

### DIFF
--- a/src/Factories/DoctrineFactory.php
+++ b/src/Factories/DoctrineFactory.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Factories;
 
+use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
@@ -29,7 +30,7 @@ class DoctrineFactory {
 	public function getEntityManager(): EntityManager {
 		if ( $this->entityManager === null ) {
 			$connection = $this->getConnection();
-			$this->entityManager = new EntityManager( $connection, $this->config );
+			$this->entityManager = new EntityManager( $connection, $this->config, new EventManager() );
 			$this->contextFactories->registerCustomTypes( $connection );
 		}
 		return $this->entityManager;


### PR DESCRIPTION
When the EntityManager is not given an EventManager instance, it'll try
to pull it from the DBAL, which leads to a deprecation warning. This
commit adds an EventManager to the EntityManager constructor. This will
make the application log much smaller.
