### PR TITLE
Improve Sofort notification behavior

### DIFF
--- a/app/Controllers/Payment/SofortNotificationController.php
+++ b/app/Controllers/Payment/SofortNotificationController.php
@@ -46,6 +46,10 @@ class SofortNotificationController {
 			return new Response( 'Ok', Response::HTTP_OK );
 		}
 
+		if ( $response->paymentWasAlreadyCompleted() ) {
+			return new Response( 'Ok', Response::HTTP_OK );
+		}
+
 		return new Response( 'Bad request', Response::HTTP_BAD_REQUEST );
 	}
 


### PR DESCRIPTION
Don't return a "400 - Bad Request" message when a payment has already been booked. Instead, just log the incident. Otherwise, Sofort will retry 5 times.

Improve SofortPaymentNotificationRouteTest by removing the deprecated createEnvironment method. This leads to a lot of indentation changes. The only *real* change in the test is the test case `testGivenAlreadyConfirmedPayment_requestDataIsLogged`, where we now expect a "Ok" reponse instead of an error response.