### PR TITLE
Fix getSalutation call

### DIFF
--- a/src/Infrastructure/Translation/GreetingGenerator.php
+++ b/src/Infrastructure/Translation/GreetingGenerator.php
@@ -60,7 +60,7 @@ class GreetingGenerator {
 	}
 
 	private function getSalutationTranslationKey( ?string $salutation, string $greetingType ): string {
-		$salutationConfig = $this->salutations->getSalutation( $salutation );
+		$salutationConfig = $this->salutations->getSalutation( $salutation ?? '' );
 		if ( !$salutation || !$salutationConfig ) {
 			return $this->genericGreeting;
 		}


### PR DESCRIPTION
The mismatch of arguments and parameters `?string` and `string` led to a
type error. This also occurs on payment notifications.
