### PR TITLE
Update Wikipedia logo in OpenGraph image

### DIFF
--- a/skins/laika/templates/Base_Layout.html.twig
+++ b/skins/laika/templates/Base_Layout.html.twig
@@ -13,7 +13,7 @@
     <meta property="og:title" content="{$ site_metadata.wikimedia_call_to_action $}" />
     <meta property="og:type" content="non_profit" />
     <meta property="og:url" content="https://spenden.wikimedia.de/" />
-    <meta property="og:image" content="https://upload.wikimedia.org/wikipedia/commons/thumb/1/13/Wikipedia_svg_logo-de.svg/200px-Wikipedia_svg_logo-de.svg.png" />
+    <meta property="og:image" content="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Wikipedia-logo-v2-de.svg/200px-Wikipedia-logo-v2-de.svg.png" />
     <meta property="og:site_name" content="{$ site_metadata.wikimedia_organization_title $}" />
     <meta property="og:description" content="{$ site_metadata.wikimedia_description $}" />
 


### PR DESCRIPTION
It was using the old (v1) logo rather than the new (v2) one.