### PR TITLE
Use a different e-mail signature when sending moderation mails

### DIFF
--- a/app/mail_templates/Donation_Confirmation.txt.twig
+++ b/app/mail_templates/Donation_Confirmation.txt.twig
@@ -80,8 +80,13 @@
 	{$ mail_content('donation_confirmation/greetings', { 'day_of_the_week': day_of_the_week } ) $}
 {% endif %}
 
-{$ mail_content('name_head_of_organization') $}
-{$ mail_content('title_head_of_organization') $}
+{% if donation.moderationFlags.AMOUNT_TOO_HIGH is defined %}
+	{$ mail_content('large_account_manager_name') $}
+	{$ mail_content('large_account_manager_department') $}
+{% else %}
+	{$ mail_content('name_head_of_organization') $}
+	{$ mail_content('title_head_of_organization') $}
+{% endif %}
 
 {% if donation.paymentType == 'MCP' and donation.interval > 0 %}
 	{$ mail_content('donation_confirmation/creditcard_interval_notice') $}

--- a/tests/Data/GeneratedMailTemplates/Donation_Confirmation.moderated_amount_too_high.txt
+++ b/tests/Data/GeneratedMailTemplates/Donation_Confirmation.moderated_amount_too_high.txt
@@ -3,8 +3,8 @@ mail_introduction_female_lastname_informal
 donation_confirmation/moderation_amount_too_high
 donation_confirmation/greetings
 
-name_head_of_organization
-title_head_of_organization
+large_account_manager_name
+large_account_manager_department
 
 ---------------------------------------------------------------------------
 wikimedia_vision


### PR DESCRIPTION
- When direct debit donations are received with an amount above a certain threshold we check back with the donor before collecting the amount from the bank account and use correct signature for this.
- Use correct signature for this

Ticket: https://phabricator.wikimedia.org/T342844