### PR TITLE
Prepare Symfony config for Symfony 7.0

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -18,3 +18,8 @@ framework:
 
     mailer:
         dsn: 'native://default'
+
+    handle_all_throwables: true
+
+    validation:
+        email_validation_mode: html5


### PR DESCRIPTION
When using Symfony 6.4 classes, we get some linting warnings for deprecated/default values in Symfony 7.

This change sets the recommended default values. We might try and remove those values after upgrading to Symfony 7