### PR TITLE
Clean up translations passed to frontend

### DIFF
--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1766,8 +1766,6 @@ class FunFunFactory implements LoggerAwareInterface {
 		return $this->createSharedObject( TranslationsCollector::class, function (): TranslationsCollector {
 			$translationsCollector = new TranslationsCollector( new SimpleFileFetcher() );
 			$translationsCollector->addTranslationFile( $this->getI18nDirectory() . '/messages/messages.json' );
-			$translationsCollector->addTranslationFile( $this->getI18nDirectory() . '/messages/membershipTypes.json' );
-			$translationsCollector->addTranslationFile( $this->getI18nDirectory() . '/messages/validations.json' );
 			return $translationsCollector;
 		} );
 	}


### PR DESCRIPTION
The contents of the files `membershipTypes.json` and `validations.json`
are not used on the frontend, so we can remove them.

Ticket: https://phabricator.wikimedia.org/T355124
