### PR TITLE
Rebuild Drone cache before running tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,12 +26,6 @@ steps:
       - echo -e "machine github.com\n  login $GITHUB_TOKEN" > ~/.netrc
       - composer config -g github-oauth.github.com "$GITHUB_TOKEN"
       - composer install --prefer-dist --no-progress --no-interaction
-      # CI
-      - vendor/bin/phpcs
-      - php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-clover coverage.xml
-      - php -d memory_limit=1G vendor/bin/phpstan analyse --level=5 --no-progress src/ tests/
-      # Upload coverage to Scrutinizer
-      - ocular code-coverage:upload --no-interaction --format=php-clover coverage.xml
 
   - name: rebuild-cache
     image: drillster/drone-volume-cache
@@ -42,6 +36,15 @@ steps:
     volumes:
       - name: cache
         path: /cache
+
+  - name: test
+    image: registry.gitlab.com/fun-tech/fundraising-frontend-docker:ci
+    commands:
+      - vendor/bin/phpcs
+      - php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-clover coverage.xml
+      - php -d memory_limit=1G vendor/bin/phpstan analyse --level=5 --no-progress src/ tests/
+      # Upload coverage to Scrutinizer
+      - ocular code-coverage:upload --no-interaction --format=php-clover coverage.xml
 
 volumes:
   - name: cache


### PR DESCRIPTION
Our CI fails randomly, with an error that files are missing. This looks like it's coming from a phpStan cleanup that's happening simultaneously with the cache rebuild step.

This commit moves the rebuild cache step between the build and test steps so it will rebuild the cache before Stan runs.