### PR TITLE
Move responsibility for translation encoding

### DIFF
--- a/cli/ApplicationConfigValidation/ValidateApplicationConfigCommand.php
+++ b/cli/ApplicationConfigValidation/ValidateApplicationConfigCommand.php
@@ -53,7 +53,12 @@ class ValidateApplicationConfigCommand extends Command {
 		$configObject = $this->loadConfigObjectFromFiles( $input->getArgument( 'config_file' ) );
 
 		if ( $input->getOption( 'dump-config' ) ) {
-			$output->writeln( json_encode( $configObject, JSON_PRETTY_PRINT ) );
+			$result = json_encode( $configObject, JSON_PRETTY_PRINT );
+			if ( $result === false ) {
+				throw new \RuntimeException( sprintf( "Failed to get JSON representation of: %s",
+					var_export( $configObject, true ) ) );
+			}
+			$output->writeln( $result );
 		}
 
 		$schema = ( new SchemaLoader( new SimpleFileFetcher() ) )->loadSchema( $input->getOption( 'schema' ) );

--- a/skins/laika/templates/Access_Denied.twig
+++ b/skins/laika/templates/Access_Denied.twig
@@ -10,7 +10,7 @@
     <div id="appdata"
          class="is-hidden"
          data-application-vars="{$ _context|json_encode|e('html_attr') $}"
-         data-application-messages="{$ translations()|e('html_attr') $}"
+         data-application-messages="{$ translations|json_encode|e('html_attr') $}"
          data-assets-path="{$ asset( '', 'skin') $}">
     </div>
 {% endblock %}

--- a/skins/laika/templates/Base_Layout.html.twig
+++ b/skins/laika/templates/Base_Layout.html.twig
@@ -62,7 +62,7 @@
     <div
         id="appdata"
         data-application-vars="{$ _context|json_encode|e('html_attr') $}"
-        data-application-messages="{$ translations()|e('html_attr') $}"
+        data-application-messages="{$ translations|json_encode|e('html_attr') $}"
         data-assets-path="{$ asset( '', 'skin') $}"
         class="is-hidden"
     ></div>

--- a/skins/laika/templates/Page_Not_Found.html.twig
+++ b/skins/laika/templates/Page_Not_Found.html.twig
@@ -10,7 +10,7 @@
 	<div id="appdata"
 		 class="is-hidden"
 		 data-application-vars="{$ _context|json_encode|e('html_attr') $}"
-		 data-application-messages="{$ translations()|e('html_attr') $}"
+		 data-application-messages="{$ translations|json_encode|e('html_attr') $}"
 		 data-assets-path="{$ asset( '', 'skin') $}">
 	</div>
 {% endblock %}

--- a/skins/laika/templates/page_layouts/base.html.twig
+++ b/skins/laika/templates/page_layouts/base.html.twig
@@ -16,7 +16,7 @@
 		data-page-title="{$ title | e('html_attr') $}"
 		data-page-content="{$ content | e('html_attr') | raw $}"
 		data-application-vars="{$ _context|json_encode|e('html_attr') $}"
-		data-application-messages="{$ translations()|e('html_attr') $}"
+		data-application-messages="{$ translations|json_encode|e('html_attr') $}"
 		data-assets-path="{$ asset( '', 'skin') $}">
 	</div>
 

--- a/skins/laika/templates/page_layouts/privacy_protection.html.twig
+++ b/skins/laika/templates/page_layouts/privacy_protection.html.twig
@@ -16,7 +16,7 @@
 		data-page-title="{$ title | e('html_attr') $}"
 		data-page-content="{$ content | e('html_attr') | raw $}"
 		data-application-vars="{$ _context|json_encode|e('html_attr') $}"
-		data-application-messages="{$ translations()|e('html_attr') $}"
+		data-application-messages="{$ translations|json_encode|e('html_attr') $}"
 		data-assets-path="{$ asset( '', 'skin') $}"
 		data-tracking-url="{$ piwik.baseUrl | e('html_attr') $}">
 	</div>

--- a/src/BucketTesting/Logging/JsonBucketLogger.php
+++ b/src/BucketTesting/Logging/JsonBucketLogger.php
@@ -20,7 +20,12 @@ class JsonBucketLogger implements BucketLogger {
 	}
 
 	public function writeEvent( LoggingEvent $event, Bucket ...$buckets ): void {
-		$this->logWriter->write( json_encode( $this->formatData( $event, ...$buckets ) ) );
+		$result = json_encode( $this->formatData( $event, ...$buckets ) );
+		if ( $result === false ) {
+			throw new \RuntimeException( sprintf( "Failed to get JSON representation of: %s",
+				var_export( $this->formatData( $event, ...$buckets ), true ) ) );
+		}
+		$this->logWriter->write( $result );
 	}
 
 	private function formatData( LoggingEvent $event, Bucket ...$buckets ): array {

--- a/src/BucketTesting/Validation/CampaignUtilizationValidator.php
+++ b/src/BucketTesting/Validation/CampaignUtilizationValidator.php
@@ -105,6 +105,11 @@ class CampaignUtilizationValidator {
 	}
 
 	private function getCampaignNameFromFeatureToggle( string $featureToggle ): string {
-		return substr( $featureToggle, 0, strrpos( $featureToggle, '.' ) );
+		$strpos = strrpos( $featureToggle, '.' );
+		if ( $strpos === false ) {
+			throw new \RuntimeException( 'Failed to find the position of the last occurrence of "." 
+			in the string: ' . $featureToggle );
+		}
+		return substr( $featureToggle, 0, $strpos );
 	}
 }

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -466,7 +466,6 @@ class FunFunFactory implements LoggerAwareInterface {
 			$factory = new WebTemplatingFactory(
 				$config,
 				$this->getCachePath() . '/twig',
-				$this->getTranslationCollector()->collectTranslations(),
 				$this->getContentProvider(),
 				$packageFactory->newAssetPackages()
 			);
@@ -475,6 +474,7 @@ class FunFunFactory implements LoggerAwareInterface {
 					'basepath' => $this->config['web-basepath'],
 					'assets_path' => $this->config['assets-path'],
 					'application_environment' => $this->getApplicationEnvironment(),
+					'translations' => $this->getTranslationCollector()->collectTranslations()
 				]
 			);
 		} );

--- a/src/Factories/WebTemplatingFactory.php
+++ b/src/Factories/WebTemplatingFactory.php
@@ -12,13 +12,11 @@ use WMDE\Fundraising\ContentProvider\ContentProvider;
 
 class WebTemplatingFactory extends TwigFactory {
 
-	private array $translations;
 	private ContentProvider $contentProvider;
 	private Packages $packages;
 
-	public function __construct( array $config, string $cachePath, array $translations, ContentProvider $contentProvider, Packages $assetPackages ) {
+	public function __construct( array $config, string $cachePath, ContentProvider $contentProvider, Packages $assetPackages ) {
 		parent::__construct( $config, $cachePath );
-		$this->translations = $translations;
 		$this->contentProvider = $contentProvider;
 		$this->packages = $assetPackages;
 	}
@@ -35,19 +33,7 @@ class WebTemplatingFactory extends TwigFactory {
 					return $this->contentProvider->getWeb( $name, $context );
 				},
 				[ 'is_safe' => [ 'html' ] ]
-			),
-			new TwigFunction(
-				'translations',
-				function (): string {
-					$result = json_encode( $this->translations );
-					if ( $result === false ) {
-						throw new \RuntimeException( sprintf( "Failed to get JSON representation of: %s",
-							var_export( $this->translations, true ) ) );
-					}
-					return $result;
-				},
-				[ 'is_safe' => [ 'html' ] ]
-			),
+			)
 		];
 	}
 

--- a/src/Factories/WebTemplatingFactory.php
+++ b/src/Factories/WebTemplatingFactory.php
@@ -39,7 +39,12 @@ class WebTemplatingFactory extends TwigFactory {
 			new TwigFunction(
 				'translations',
 				function (): string {
-					return json_encode( $this->translations );
+					$result = json_encode( $this->translations );
+					if ( $result === false ) {
+						throw new \RuntimeException( sprintf( "Failed to get JSON representation of: %s",
+							var_export( $this->translations, true ) ) );
+					}
+					return $result;
 				},
 				[ 'is_safe' => [ 'html' ] ]
 			),

--- a/src/Infrastructure/ConfigReader.php
+++ b/src/Infrastructure/ConfigReader.php
@@ -75,7 +75,12 @@ class ConfigReader {
 		if ( empty( $config['twig']['loaders']['array'] ) ) {
 			$config['twig']['loaders']['array'] = new stdClass();
 		}
-		return json_decode( json_encode( $config ), false );
+		$result = json_encode( $config );
+		if ( $result === false ) {
+			throw new \RuntimeException( sprintf( "Failed to get JSON representation of: %s",
+				var_export( $config, true ) ) );
+		}
+		return json_decode( $result, false );
 	}
 
 }

--- a/src/Infrastructure/Mail/MailTemplateFilenameTraversable.php
+++ b/src/Infrastructure/Mail/MailTemplateFilenameTraversable.php
@@ -14,7 +14,12 @@ class MailTemplateFilenameTraversable implements \IteratorAggregate {
 	}
 
 	public function getIterator(): \Iterator {
-		foreach ( glob( $this->mailTemplatePath . '/*\.twig' ) as $fileName ) {
+		$glob = glob( $this->mailTemplatePath . '/*\.twig' );
+		if ( $glob === false ) {
+			throw new \RuntimeException( sprintf( "Failed to find path name: %s",
+				var_export( $this->mailTemplatePath . '/*\.twig', true ) ) );
+		}
+		foreach ( $glob as $fileName ) {
 			yield basename( $fileName );
 		}
 	}

--- a/src/Infrastructure/SkinCacheWarmer.php
+++ b/src/Infrastructure/SkinCacheWarmer.php
@@ -44,7 +44,11 @@ class SkinCacheWarmer implements CacheWarmerInterface {
 	private function getTemplates(): array {
 		$cacheDirectory = $this->funFunFactory->getSkinDirectory();
 		$templates = [];
-		foreach ( scandir( $cacheDirectory ) as $file ) {
+		$scandir = scandir( $cacheDirectory );
+		if ( $scandir === false ) {
+			throw new \RuntimeException( 'Failed to list files and directories inside this specified path: ' . $cacheDirectory );
+		}
+		foreach ( $scandir as $file ) {
 			if ( !is_dir( $file ) && str_contains( $file, '.twig' ) ) {
 				$templates[] = $file;
 			}

--- a/src/Infrastructure/UserDataKeyGenerator.php
+++ b/src/Infrastructure/UserDataKeyGenerator.php
@@ -20,7 +20,12 @@ class UserDataKeyGenerator {
 
 	public function getDailyKey(): string {
 		$now = $this->time->now();
-		$daysSince2020 = abs( $now->diff( new \DateTimeImmutable( self::START_TIME ) )->days );
+		$days = $now->diff( new \DateTimeImmutable( self::START_TIME ) )->days;
+		if ( $days === false ) {
+			throw new \RuntimeException( sprintf( "Failed to get the total number of days in the interval span: %s",
+				var_export( $now->diff( new \DateTimeImmutable( self::START_TIME ) ), true ) ) );
+		}
+		$daysSince2020 = abs( $days );
 		return sodium_bin2base64(
 			sodium_crypto_kdf_derive_from_key(
 				32,

--- a/tests/EdgeToEdge/Routes/CreditCardPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/CreditCardPaymentNotificationRouteTest.php
@@ -46,8 +46,13 @@ class CreditCardPaymentNotificationRouteTest extends WebRouteTestCase {
 			);
 
 			$this->assertSame( 1, $logger->getLogCalls()->count() );
-			$this->assertStringContainsString( "status=error\n", $client->getResponse()->getContent() );
-			$this->assertStringContainsString( 'msg=', $client->getResponse()->getContent() );
+			$content = $client->getResponse()->getContent();
+			if ( $content === false ) {
+				throw new \RuntimeException( sprintf( "Failed to get the content of: %s",
+					var_export( $client->getResponse(), true ) ) );
+			}
+			$this->assertStringContainsString( "status=error\n", $content );
+			$this->assertStringContainsString( 'msg=', $content );
 		} );
 	}
 
@@ -63,8 +68,13 @@ class CreditCardPaymentNotificationRouteTest extends WebRouteTestCase {
 				]
 			);
 			$this->assertSame( 200, $client->getResponse()->getStatusCode() );
-			$this->assertStringContainsString( "status=error\n", $client->getResponse()->getContent() );
-			$this->assertStringContainsString( 'msg=Function "error" not supported by this end point', $client->getResponse()->getContent() );
+			$content = $client->getResponse()->getContent();
+			if ( $content === false ) {
+				throw new \RuntimeException( sprintf( "Failed to get the content of: %s",
+					var_export( $client->getResponse(), true ) ) );
+			}
+			$this->assertStringContainsString( "status=error\n", $content );
+			$this->assertStringContainsString( 'msg=Function "error" not supported by this end point', $content );
 		} );
 	}
 
@@ -100,10 +110,15 @@ class CreditCardPaymentNotificationRouteTest extends WebRouteTestCase {
 			);
 
 			$this->assertSame( 200, $client->getResponse()->getStatusCode() );
-			$this->assertStringContainsString( "status=ok\n", $client->getResponse()->getContent() );
+			$content = $client->getResponse()->getContent();
+			if ( $content === false ) {
+				throw new \RuntimeException( sprintf( "Failed to get the content of: %s",
+					var_export( $client->getResponse(), true ) ) );
+			}
+			$this->assertStringContainsString( "status=ok\n", $content );
 			$this->assertStringContainsString(
 				"url=http://my.donation.app/show-donation-confirmation?id=1&accessToken=my_secret_access_token\n",
-				$client->getResponse()->getContent()
+				$content
 			);
 			$this->assertCreditCardDataGotPersisted(
 				$factory->getDonationRepository(),
@@ -122,8 +137,13 @@ class CreditCardPaymentNotificationRouteTest extends WebRouteTestCase {
 			);
 
 			$this->assertSame( 200, $client->getResponse()->getStatusCode() );
-			$this->assertStringContainsString( "status=error\n", $client->getResponse()->getContent() );
-			$this->assertStringContainsString( "msg=Donation not found\n", $client->getResponse()->getContent() );
+			$content = $client->getResponse()->getContent();
+			if ( $content === false ) {
+				throw new \RuntimeException( sprintf( "Failed to get the content of: %s",
+					var_export( $client->getResponse(), true ) ) );
+			}
+			$this->assertStringContainsString( "status=error\n", $content );
+			$this->assertStringContainsString( "msg=Donation not found\n", $content );
 		} );
 	}
 
@@ -160,7 +180,12 @@ class CreditCardPaymentNotificationRouteTest extends WebRouteTestCase {
 			);
 
 			$this->assertSame( 500, $client->getResponse()->getStatusCode() );
-			$this->assertStringContainsString( "Could not get donation", $client->getResponse()->getContent() );
+			$content = $client->getResponse()->getContent();
+			if ( $content === false ) {
+				throw new \RuntimeException( sprintf( "Failed to get the content of: %s",
+					var_export( $client->getResponse(), true ) ) );
+			}
+			$this->assertStringContainsString( "Could not get donation", $content );
 		} );
 	}
 

--- a/tests/EdgeToEdge/Routes/ShowDonationConfirmationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ShowDonationConfirmationRouteTest.php
@@ -145,7 +145,12 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 				]
 			);
 
-			$this->assertDonationIsNotShown( $this->donation, $client->getResponse()->getContent() );
+			$content = $client->getResponse()->getContent();
+			if ( $content === false ) {
+				throw new \RuntimeException( sprintf( "Failed to get the content of: %s",
+					var_export( $client->getResponse(), true ) ) );
+			}
+			$this->assertDonationIsNotShown( $this->donation, $content );
 		} );
 	}
 

--- a/tests/EdgeToEdge/Routes/ShowMembershipConfirmationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ShowMembershipConfirmationRouteTest.php
@@ -124,7 +124,12 @@ class ShowMembershipConfirmationRouteTest extends WebRouteTestCase {
 	}
 
 	private function assertAccessIsDenied( string $expectedMessage, Client $client ): void {
-		$this->assertStringContainsString( $expectedMessage, $client->getResponse()->getContent() );
+		$content = $client->getResponse()->getContent();
+		if ( $content === false ) {
+			throw new \RuntimeException( sprintf( "Failed to get the content of: %s",
+				var_export( $client->getResponse(), true ) ) );
+		}
+		$this->assertStringContainsString( $expectedMessage, $content );
 		$this->assertTrue( $client->getResponse()->isForbidden() );
 	}
 

--- a/tests/EdgeToEdge/WebRouteTestCase.php
+++ b/tests/EdgeToEdge/WebRouteTestCase.php
@@ -177,7 +177,12 @@ abstract class WebRouteTestCase extends KernelTestCase {
 
 	protected function assertJsonSuccessResponse( array $expected, Response $response ): void {
 		$this->assertTrue( $response->isSuccessful(), 'request is successful' );
-		$this->assertJson( $response->getContent(), 'response is json' );
+		$content = $response->getContent();
+		if ( $content === false ) {
+			throw new \RuntimeException( sprintf( "Failed to get the content of: %s",
+				var_export( $response, true ) ) );
+		}
+		$this->assertJson( $content, 'response is json' );
 		$this->assertJsonResponse( $expected, $response );
 	}
 
@@ -195,8 +200,17 @@ abstract class WebRouteTestCase extends KernelTestCase {
 	}
 
 	protected function getJsonFromResponse( Response $response ): array {
-		$this->assertJson( $response->getContent(), 'response is json' );
-		return json_decode( $response->getContent(), true );
+		$content = $response->getContent();
+		if ( $content === false ) {
+			throw new \RuntimeException( sprintf( "Failed to get the content of: %s",
+				var_export( $response, true ) ) );
+		}
+		$this->assertJson( $content, 'response is json' );
+		$result = json_decode( $content, true );
+		if ( $result === false ) {
+			throw new \RuntimeException( 'Failed to get JSON representation of: ' . $content );
+		}
+		return $result;
 	}
 
 	protected function assertSuccessJsonResponse( Response $response ): void {

--- a/tests/Unit/Infrastructure/ConfigReaderTest.php
+++ b/tests/Unit/Infrastructure/ConfigReaderTest.php
@@ -38,10 +38,15 @@ class ConfigReaderTest extends TestCase {
 	}
 
 	private function getDistConfigContents(): string {
-		return json_encode(
+		$result = json_encode(
 			$this->getDistConfig(),
 			JSON_PRETTY_PRINT
 		);
+		if ( $result === false ) {
+			throw new \RuntimeException( sprintf( "Failed to get JSON representation of: %s",
+				var_export( $this->getDistConfig(), true ) ) );
+		}
+		return $result;
 	}
 
 	private function getDistConfig(): array {
@@ -57,7 +62,7 @@ class ConfigReaderTest extends TestCase {
 	}
 
 	private function getInstanceConfigContents(): string {
-		return json_encode(
+		$result = json_encode(
 			[
 				'db' => [
 					'user' => 'nyan',
@@ -67,6 +72,17 @@ class ConfigReaderTest extends TestCase {
 			],
 			JSON_PRETTY_PRINT
 		);
+		if ( $result === false ) {
+			throw new \RuntimeException( sprintf( "Failed to get JSON representation of: %s", var_export(
+				[
+					'db' => [
+						'user' => 'nyan',
+						'password' => 'cat'
+					],
+					'unicorns' => [ 'foo', 'bar', 'baz' ]
+				], true ) ) );
+		}
+		return $result;
 	}
 
 	public function testReadSingleConfigFile(): void {

--- a/tests/Unit/Infrastructure/FileFeatureReaderTest.php
+++ b/tests/Unit/Infrastructure/FileFeatureReaderTest.php
@@ -47,7 +47,11 @@ class FileFeatureReaderTest extends TestCase {
 				'active' => false
 			],
 		];
-		$reader = new FileFeatureReader( new InMemoryFileFetcher( [ 'features.json' => json_encode( $rawFeatures ) ] ), 'features.json', $logger );
+		$result = json_encode( $rawFeatures );
+		if ( $result === false ) {
+			throw new \RuntimeException( sprintf( "Failed to get JSON representation of: %s", var_export( $rawFeatures, true ) ) );
+		}
+		$reader = new FileFeatureReader( new InMemoryFileFetcher( [ 'features.json' => $result ] ), 'features.json', $logger );
 
 		$features = $reader->getFeatures();
 
@@ -70,11 +74,18 @@ class FileFeatureReaderTest extends TestCase {
 
 	public function testGivenFeaturesWithoutNames_willBeSkipped(): void {
 		$logger = new LoggerSpy();
-		$featuresStr = json_encode( [
+		$result = json_encode( [
 			[ 'active' => false ],
 			[ 'name' => 'inactive_feature' ]
 		] );
-		$reader = new FileFeatureReader( new InMemoryFileFetcher( [ 'some_file.json' => $featuresStr ] ), 'some_file.json', $logger );
+		if ( $result === false ) {
+			throw new \RuntimeException( sprintf( "Failed to get JSON representation of: %s", var_export(
+				[
+					[ 'active' => false ],
+					[ 'name' => 'inactive_feature' ]
+				], true ) ) );
+		}
+		$reader = new FileFeatureReader( new InMemoryFileFetcher( [ 'some_file.json' => $result ] ), 'some_file.json', $logger );
 
 		$features = $reader->getFeatures();
 

--- a/tests/Unit/Infrastructure/PayPalAdapterConfigLoaderTest.php
+++ b/tests/Unit/Infrastructure/PayPalAdapterConfigLoaderTest.php
@@ -91,9 +91,13 @@ class PayPalAdapterConfigLoaderTest extends TestCase {
 	}
 
 	private function givenConfigFile(): vfsStreamFile {
+		$content = file_get_contents( self::TEST_CONFIG_FILE );
+		if ( $content === false ) {
+			throw new \RuntimeException( 'Failed to find the file content of: ' . self::TEST_CONFIG_FILE );
+		}
 		return vfsStream::newFile( 'paypal_api.yml' )
 			->at( $this->filesystem )
-			->setContent( file_get_contents( self::TEST_CONFIG_FILE ) )
+			->setContent( $content )
 			->lastModified( 1611619200 );
 	}
 }

--- a/tests/Unit/Infrastructure/Translation/JsonTranslatorTest.php
+++ b/tests/Unit/Infrastructure/Translation/JsonTranslatorTest.php
@@ -47,16 +47,24 @@ class JsonTranslatorTest extends TestCase {
 	}
 
 	private function newTranslationSource(): InMemoryFileFetcher {
-		$source = new InMemoryFileFetcher(
+		$result = json_encode(
 			[
-				'testytest_messages.json' => json_encode(
-					[
-						'donate_now' => 'Jetzt spenden',
-						'you_will_pay' => 'Sie spenden %amount% %interval%'
-					]
-				) ]
+				'donate_now' => 'Jetzt spenden',
+				'you_will_pay' => 'Sie spenden %amount% %interval%'
+			]
 		);
-		return $source;
+		if ( $result === false ) {
+			throw new \RuntimeException( sprintf( "Failed to get JSON representation of: %s", var_export(
+				[
+					'donate_now' => 'Jetzt spenden',
+					'you_will_pay' => 'Sie spenden %amount% %interval%'
+				], true ) ) );
+		}
+		return new InMemoryFileFetcher(
+			[
+				'testytest_messages.json' => $result
+			]
+		);
 	}
 
 }


### PR DESCRIPTION
Remove special "translations" function that just JSON encodes the translations. Instead, encode the translations inside the templates inside the array.

This helps us avoiding unnecessary checks for `false` on `json_encode`, since all the translations are already "pre-validated" because they were loaded with `json_decode` in the TranslattionCollector class.