### PR TITLE
Adapt to new membership mailer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"wmde/euro": "~1.0",
 		"wmde/clock": "~1.0",
 		"wmde/fundraising-donations": "~17.0",
-		"wmde/fundraising-memberships": "~14.0",
+		"wmde/fundraising-memberships": "dev-upgrade-phpstan-level",
 		"wmde/fundraising-payments": "~7.0",
 		"wmde/fundraising-subscriptions": "~5.0",
 		"wmde/fundraising-content-provider": "~6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c25f965cf9f1123d5cf25ff10150385",
+    "content-hash": "060d31eab4f9b099597d43567dd76045",
     "packages": [
         {
             "name": "airbrake/phpbrake",
@@ -170,16 +170,16 @@
         },
         {
             "name": "doctrine/collections",
-            "version": "2.2.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/collections.git",
-                "reference": "07e16cd7b80a2cffed99e36b541876af172f0257"
+                "reference": "420480fc085bc65f3c956af13abe8e7546f94813"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/collections/zipball/07e16cd7b80a2cffed99e36b541876af172f0257",
-                "reference": "07e16cd7b80a2cffed99e36b541876af172f0257",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/420480fc085bc65f3c956af13abe8e7546f94813",
+                "reference": "420480fc085bc65f3c956af13abe8e7546f94813",
                 "shasum": ""
             },
             "require": {
@@ -236,7 +236,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/collections/issues",
-                "source": "https://github.com/doctrine/collections/tree/2.2.0"
+                "source": "https://github.com/doctrine/collections/tree/2.2.1"
             },
             "funding": [
                 {
@@ -252,20 +252,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-25T22:55:36+00:00"
+            "time": "2024-03-05T22:28:45+00:00"
         },
         {
             "name": "doctrine/dbal",
-            "version": "4.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "53df8c432978b716a805143eb701436d54ec705e"
+                "reference": "9e588fe1f38a443cb17de6b86b803d9e028e2156"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/53df8c432978b716a805143eb701436d54ec705e",
-                "reference": "53df8c432978b716a805143eb701436d54ec705e",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/9e588fe1f38a443cb17de6b86b803d9e028e2156",
+                "reference": "9e588fe1f38a443cb17de6b86b803d9e028e2156",
                 "shasum": ""
             },
             "require": {
@@ -278,16 +278,16 @@
                 "doctrine/coding-standard": "12.0.0",
                 "fig/log-test": "^1",
                 "jetbrains/phpstorm-stubs": "2023.2",
-                "phpstan/phpstan": "1.10.57",
+                "phpstan/phpstan": "1.10.58",
                 "phpstan/phpstan-phpunit": "1.3.15",
                 "phpstan/phpstan-strict-rules": "^1.5",
                 "phpunit/phpunit": "10.5.9",
                 "psalm/plugin-phpunit": "0.18.4",
                 "slevomat/coding-standard": "8.13.1",
-                "squizlabs/php_codesniffer": "3.8.1",
+                "squizlabs/php_codesniffer": "3.9.0",
                 "symfony/cache": "^6.3.8|^7.0",
                 "symfony/console": "^5.4|^6.3|^7.0",
-                "vimeo/psalm": "5.16.0"
+                "vimeo/psalm": "5.21.1"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -344,7 +344,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/4.0.0"
+                "source": "https://github.com/doctrine/dbal/tree/4.0.1"
             },
             "funding": [
                 {
@@ -360,7 +360,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-03T19:11:19+00:00"
+            "time": "2024-03-03T15:59:11+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -740,16 +740,16 @@
         },
         {
             "name": "doctrine/migrations",
-            "version": "3.7.2",
+            "version": "3.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "47af29eef49f29ebee545947e8b2a4b3be318c8a"
+                "reference": "954e0a314c2f0eb9fb418210445111747de254a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/47af29eef49f29ebee545947e8b2a4b3be318c8a",
-                "reference": "47af29eef49f29ebee545947e8b2a4b3be318c8a",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/954e0a314c2f0eb9fb418210445111747de254a6",
+                "reference": "954e0a314c2f0eb9fb418210445111747de254a6",
                 "shasum": ""
             },
             "require": {
@@ -822,7 +822,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/migrations/issues",
-                "source": "https://github.com/doctrine/migrations/tree/3.7.2"
+                "source": "https://github.com/doctrine/migrations/tree/3.7.4"
             },
             "funding": [
                 {
@@ -838,32 +838,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-05T11:35:05+00:00"
+            "time": "2024-03-06T13:41:11+00:00"
         },
         {
             "name": "doctrine/orm",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "2a250b5814de192a23438c0a43e15da7e77890a7"
+                "reference": "716fc97b70cf8116f74eaa0588eef51420874bf9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/2a250b5814de192a23438c0a43e15da7e77890a7",
-                "reference": "2a250b5814de192a23438c0a43e15da7e77890a7",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/716fc97b70cf8116f74eaa0588eef51420874bf9",
+                "reference": "716fc97b70cf8116f74eaa0588eef51420874bf9",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2",
-                "doctrine/collections": "^2.1",
+                "doctrine/collections": "^2.2",
                 "doctrine/dbal": "^3.8.2 || ^4",
                 "doctrine/deprecations": "^0.5.3 || ^1",
                 "doctrine/event-manager": "^1.2 || ^2",
                 "doctrine/inflector": "^1.4 || ^2.0",
                 "doctrine/instantiator": "^1.3 || ^2",
                 "doctrine/lexer": "^3",
-                "doctrine/persistence": "^3.1.1",
+                "doctrine/persistence": "^3.3.1",
                 "ext-ctype": "*",
                 "php": "^8.1",
                 "psr/cache": "^1 || ^2 || ^3",
@@ -873,12 +873,12 @@
             "require-dev": {
                 "doctrine/coding-standard": "^12.0",
                 "phpbench/phpbench": "^1.0",
-                "phpstan/phpstan": "1.10.35",
+                "phpstan/phpstan": "1.10.59",
                 "phpunit/phpunit": "^10.4.0",
                 "psr/log": "^1 || ^2 || ^3",
                 "squizlabs/php_codesniffer": "3.7.2",
                 "symfony/cache": "^5.4 || ^6.2 || ^7.0",
-                "vimeo/psalm": "5.16.0"
+                "vimeo/psalm": "5.22.2"
             },
             "suggest": {
                 "ext-dom": "Provides support for XSD validation for XML mapping files",
@@ -924,22 +924,22 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/3.0.1"
+                "source": "https://github.com/doctrine/orm/tree/3.1.0"
             },
-            "time": "2024-02-22T12:23:53+00:00"
+            "time": "2024-03-03T17:45:20+00:00"
         },
         {
             "name": "doctrine/persistence",
-            "version": "3.2.0",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "63fee8c33bef740db6730eb2a750cd3da6495603"
+                "reference": "477da35bd0255e032826f440b94b3e37f2d56f42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/63fee8c33bef740db6730eb2a750cd3da6495603",
-                "reference": "63fee8c33bef740db6730eb2a750cd3da6495603",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/477da35bd0255e032826f440b94b3e37f2d56f42",
+                "reference": "477da35bd0255e032826f440b94b3e37f2d56f42",
                 "shasum": ""
             },
             "require": {
@@ -1008,7 +1008,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/persistence/issues",
-                "source": "https://github.com/doctrine/persistence/tree/3.2.0"
+                "source": "https://github.com/doctrine/persistence/tree/3.3.2"
             },
             "funding": [
                 {
@@ -1024,7 +1024,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-17T18:32:04+00:00"
+            "time": "2024-03-12T14:54:36+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -3669,16 +3669,16 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v6.4.4",
+            "version": "v6.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "aa6281ddb3be1b3088f329307d05abfbbeb97649"
+                "reference": "f3c86a60a3615f466333a11fd42010d4382a82c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/aa6281ddb3be1b3088f329307d05abfbbeb97649",
-                "reference": "aa6281ddb3be1b3088f329307d05abfbbeb97649",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/f3c86a60a3615f466333a11fd42010d4382a82c7",
+                "reference": "f3c86a60a3615f466333a11fd42010d4382a82c7",
                 "shasum": ""
             },
             "require": {
@@ -3742,7 +3742,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v6.4.4"
+                "source": "https://github.com/symfony/http-client/tree/v6.4.5"
             },
             "funding": [
                 {
@@ -3758,7 +3758,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-14T16:28:12+00:00"
+            "time": "2024-03-02T12:45:30+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -3917,16 +3917,16 @@
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.4.4",
+            "version": "v6.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "7a186f64a7f02787c04e8476538624d6aa888e42"
+                "reference": "f6947cb939d8efee137797382cb4db1af653ef75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/7a186f64a7f02787c04e8476538624d6aa888e42",
-                "reference": "7a186f64a7f02787c04e8476538624d6aa888e42",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/f6947cb939d8efee137797382cb4db1af653ef75",
+                "reference": "f6947cb939d8efee137797382cb4db1af653ef75",
                 "shasum": ""
             },
             "require": {
@@ -4010,7 +4010,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.4.4"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.4.5"
             },
             "funding": [
                 {
@@ -4026,7 +4026,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-27T06:32:13+00:00"
+            "time": "2024-03-04T21:00:47+00:00"
         },
         {
             "name": "symfony/intl",
@@ -5228,16 +5228,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v6.4.3",
+            "version": "v6.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "3b2957ad54902f0f544df83e3d58b38d7e8e5842"
+                "reference": "7fe30068e207d9c31c0138501ab40358eb2d49a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/3b2957ad54902f0f544df83e3d58b38d7e8e5842",
-                "reference": "3b2957ad54902f0f544df83e3d58b38d7e8e5842",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/7fe30068e207d9c31c0138501ab40358eb2d49a4",
+                "reference": "7fe30068e207d9c31c0138501ab40358eb2d49a4",
                 "shasum": ""
             },
             "require": {
@@ -5291,7 +5291,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.4.3"
+                "source": "https://github.com/symfony/routing/tree/v6.4.5"
             },
             "funding": [
                 {
@@ -5307,7 +5307,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-30T13:55:02+00:00"
+            "time": "2024-02-27T12:33:30+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6597,21 +6597,21 @@
         },
         {
             "name": "wmde/fundraising-memberships",
-            "version": "v14.0.0",
+            "version": "dev-upgrade-phpstan-level",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-memberships",
-                "reference": "4f8b709d40855db42a18786f5c49fa85ed3f0e62"
+                "reference": "2c0adf279b5d217201c06cd71f5b4c816c50e63c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-memberships/zipball/4f8b709d40855db42a18786f5c49fa85ed3f0e62",
-                "reference": "4f8b709d40855db42a18786f5c49fa85ed3f0e62",
+                "url": "https://api.github.com/repos/wmde/fundraising-memberships/zipball/2c0adf279b5d217201c06cd71f5b4c816c50e63c",
+                "reference": "2c0adf279b5d217201c06cd71f5b4c816c50e63c",
                 "shasum": ""
             },
             "require": {
                 "doctrine/migrations": "^3.5",
-                "doctrine/orm": "~2.18 | ~3.0",
+                "doctrine/orm": "~3.0",
                 "php": ">=8.1",
                 "psr/log": "~3.0",
                 "wmde/email-address": "~1.0",
@@ -6621,8 +6621,9 @@
                 "wmde/fundraising-payments": "~7.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "~1.2",
-                "phpstan/phpstan-phpunit": "~1.0",
+                "phpstan/phpstan": "^1.10",
+                "phpstan/phpstan-doctrine": "~1.3.62",
+                "phpstan/phpstan-phpunit": "^1.3",
                 "phpunit/phpunit": "~10.4.0",
                 "symfony/cache": "^6.1",
                 "wmde/fundraising-phpcs": "~9.0.0",
@@ -6652,20 +6653,20 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Bounded Context for the Wikimedia Deutschland fundraising membership subdomain",
-            "time": "2024-02-28T14:44:39+00:00"
+            "time": "2024-03-13T16:10:37+00:00"
         },
         {
             "name": "wmde/fundraising-payments",
-            "version": "v7.0.7",
+            "version": "7.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-payments",
-                "reference": "650150f46e0c19737427d38f7d61d3a4558fd6f5"
+                "reference": "db7c652d82350acce23829ea0044b74fab4c2cca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-payments/zipball/650150f46e0c19737427d38f7d61d3a4558fd6f5",
-                "reference": "650150f46e0c19737427d38f7d61d3a4558fd6f5",
+                "url": "https://api.github.com/repos/wmde/fundraising-payments/zipball/db7c652d82350acce23829ea0044b74fab4c2cca",
+                "reference": "db7c652d82350acce23829ea0044b74fab4c2cca",
                 "shasum": ""
             },
             "require": {
@@ -6712,7 +6713,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Bounded Context for the Wikimedia Deutschland fundraising payment subdomain",
-            "time": "2024-02-08T13:18:47+00:00"
+            "time": "2024-03-06T11:05:29+00:00"
         },
         {
             "name": "wmde/fundraising-subscriptions",
@@ -6768,16 +6769,16 @@
     "packages-dev": [
         {
             "name": "composer/pcre",
-            "version": "3.1.1",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "00104306927c7a0919b4ced2aaa6782c1e61a3c9"
+                "reference": "4775f35b2d70865807c89d32c8e7385b86eb0ace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/00104306927c7a0919b4ced2aaa6782c1e61a3c9",
-                "reference": "00104306927c7a0919b4ced2aaa6782c1e61a3c9",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/4775f35b2d70865807c89d32c8e7385b86eb0ace",
+                "reference": "4775f35b2d70865807c89d32c8e7385b86eb0ace",
                 "shasum": ""
             },
             "require": {
@@ -6819,7 +6820,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.1.1"
+                "source": "https://github.com/composer/pcre/tree/3.1.2"
             },
             "funding": [
                 {
@@ -6835,7 +6836,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-11T07:11:09+00:00"
+            "time": "2024-03-07T15:38:35+00:00"
         },
         {
             "name": "composer/semver",
@@ -7420,20 +7421,21 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
@@ -7474,9 +7476,15 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
-            "time": "2021-07-20T11:28:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
@@ -7614,16 +7622,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.59",
+            "version": "1.10.62",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e607609388d3a6d418a50a49f7940e8086798281"
+                "reference": "cd5c8a1660ed3540b211407c77abf4af193a6af9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e607609388d3a6d418a50a49f7940e8086798281",
-                "reference": "e607609388d3a6d418a50a49f7940e8086798281",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/cd5c8a1660ed3540b211407c77abf4af193a6af9",
+                "reference": "cd5c8a1660ed3540b211407c77abf4af193a6af9",
                 "shasum": ""
             },
             "require": {
@@ -7672,20 +7680,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-20T13:59:13+00:00"
+            "time": "2024-03-13T12:27:20+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.11",
+            "version": "10.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "78c3b7625965c2513ee96569a4dbb62601784145"
+                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/78c3b7625965c2513ee96569a4dbb62601784145",
-                "reference": "78c3b7625965c2513ee96569a4dbb62601784145",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
+                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
                 "shasum": ""
             },
             "require": {
@@ -7742,7 +7750,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.11"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.14"
             },
             "funding": [
                 {
@@ -7750,7 +7758,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T15:38:30+00:00"
+            "time": "2024-03-12T15:33:41+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -8098,16 +8106,16 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
-                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
                 "shasum": ""
             },
             "require": {
@@ -8142,7 +8150,8 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
             },
             "funding": [
                 {
@@ -8150,7 +8159,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:15+00:00"
+            "time": "2024-03-02T07:12:49+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -8400,16 +8409,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "5.1.0",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "fbf413a49e54f6b9b17e12d900ac7f6101591b7f"
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/fbf413a49e54f6b9b17e12d900ac7f6101591b7f",
-                "reference": "fbf413a49e54f6b9b17e12d900ac7f6101591b7f",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
                 "shasum": ""
             },
             "require": {
@@ -8417,7 +8426,7 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.0",
-                "symfony/process": "^4.2 || ^5"
+                "symfony/process": "^6.4"
             },
             "type": "library",
             "extra": {
@@ -8455,7 +8464,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.0"
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
             },
             "funding": [
                 {
@@ -8463,7 +8472,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T10:55:06+00:00"
+            "time": "2024-03-02T07:15:17+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -8531,16 +8540,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.1.1",
+            "version": "5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc"
+                "reference": "955288482d97c19a372d3f31006ab3f37da47adf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/64f51654862e0f5e318db7e9dcc2292c63cdbddc",
-                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/955288482d97c19a372d3f31006ab3f37da47adf",
+                "reference": "955288482d97c19a372d3f31006ab3f37da47adf",
                 "shasum": ""
             },
             "require": {
@@ -8597,7 +8606,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.2"
             },
             "funding": [
                 {
@@ -8605,20 +8614,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-24T13:22:09+00:00"
+            "time": "2024-03-02T07:17:12+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.1",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4"
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/7ea9ead78f6d380d2a667864c132c2f7b83055e4",
-                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
                 "shasum": ""
             },
             "require": {
@@ -8652,14 +8661,14 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
             },
             "funding": [
                 {
@@ -8667,7 +8676,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-07-19T07:19:23+00:00"
+            "time": "2024-03-02T07:19:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -9284,16 +9293,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
                 "shasum": ""
             },
             "require": {
@@ -9322,7 +9331,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
             },
             "funding": [
                 {
@@ -9330,7 +9339,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-20T00:12:19+00:00"
+            "time": "2024-03-03T12:36:25+00:00"
         },
         {
             "name": "wmde/fundraising-frontend-content",
@@ -9338,12 +9347,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-frontend-content",
-                "reference": "26d116e820a11549d43c07cba072d72c9c8c521a"
+                "reference": "70d41400d01b057c9893721f13d9c30a238b2c18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/26d116e820a11549d43c07cba072d72c9c8c521a",
-                "reference": "26d116e820a11549d43c07cba072d72c9c8c521a",
+                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/70d41400d01b057c9893721f13d9c30a238b2c18",
+                "reference": "70d41400d01b057c9893721f13d9c30a238b2c18",
                 "shasum": ""
             },
             "require": {
@@ -9387,7 +9396,7 @@
                 "CC0-1.0"
             ],
             "description": "i18n for FundraisingFrontend",
-            "time": "2024-02-12T12:24:54+00:00"
+            "time": "2024-03-07T15:27:17+00:00"
         },
         {
             "name": "wmde/fundraising-phpcs",
@@ -9481,6 +9490,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "wmde/fundraising-memberships": 20,
         "airbrake/phpbrake": 20,
         "remotelyliving/doorkeeper": 20,
         "wmde/fundraising-frontend-content": 20
@@ -9500,5 +9510,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -130,11 +130,12 @@ use WMDE\Fundraising\Frontend\Infrastructure\FileFeatureReader;
 use WMDE\Fundraising\Frontend\Infrastructure\Mail\AdminModerationMailRenderer;
 use WMDE\Fundraising\Frontend\Infrastructure\Mail\BasicMailSubjectRenderer;
 use WMDE\Fundraising\Frontend\Infrastructure\Mail\DonationConfirmationMailSubjectRenderer;
-use WMDE\Fundraising\Frontend\Infrastructure\Mail\ErrorHandlingTemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\Mail\ErrorHandlingMailerDecorator;
 use WMDE\Fundraising\Frontend\Infrastructure\Mail\GetInTouchMailerInterface;
 use WMDE\Fundraising\Frontend\Infrastructure\Mail\MailSubjectRendererInterface;
 use WMDE\Fundraising\Frontend\Infrastructure\Mail\MailTemplateFilenameTraversable;
 use WMDE\Fundraising\Frontend\Infrastructure\Mail\MembershipConfirmationMailSubjectRenderer;
+use WMDE\Fundraising\Frontend\Infrastructure\Mail\MembershipMailerAdapter;
 use WMDE\Fundraising\Frontend\Infrastructure\Mail\Messenger;
 use WMDE\Fundraising\Frontend\Infrastructure\Mail\NullMailer;
 use WMDE\Fundraising\Frontend\Infrastructure\Mail\OperatorMailer;
@@ -194,7 +195,6 @@ use WMDE\Fundraising\MembershipContext\DataAccess\IncentiveFinder;
 use WMDE\Fundraising\MembershipContext\DataAccess\ModerationReasonRepository as MembershipModerationReasonRepository;
 use WMDE\Fundraising\MembershipContext\Domain\Repositories\ApplicationRepository;
 use WMDE\Fundraising\MembershipContext\Infrastructure\PaymentServiceFactory;
-use WMDE\Fundraising\MembershipContext\Infrastructure\TemplateMailerInterface as MembershipTemplateMailerInterface;
 use WMDE\Fundraising\MembershipContext\MembershipContextFactory;
 use WMDE\Fundraising\MembershipContext\Tracking\ApplicationPiwikTracker;
 use WMDE\Fundraising\MembershipContext\Tracking\ApplicationTracker;
@@ -606,8 +606,8 @@ class FunFunFactory implements LoggerAwareInterface {
 		);
 	}
 
-	private function newErrorHandlingTemplateMailer( Messenger $messenger, TwigTemplate $template, MailSubjectRendererInterface $subjectRenderer ): ErrorHandlingTemplateBasedMailer {
-		return new ErrorHandlingTemplateBasedMailer(
+	private function newErrorHandlingTemplateMailer( Messenger $messenger, TwigTemplate $template, MailSubjectRendererInterface $subjectRenderer ): ErrorHandlingMailerDecorator {
+		return new ErrorHandlingMailerDecorator(
 			$this->newTemplateMailer( $messenger, $template, $subjectRenderer ),
 			$this->getLogger()
 		);
@@ -1215,11 +1215,7 @@ class FunFunFactory implements LoggerAwareInterface {
 			$this->newMembershipAuthorizer(),
 			new MailMembershipApplicationNotifier(
 				$this->newApplyForMembershipMailer(),
-				$this->newAdminMailer(
-					'ein Mitgliedschaftsantrag',
-					'https://backend.wikimedia.de/backend/member/list',
-					$this->getAdminMessenger()
-				),
+				$this->newApplyForMembershipAdminMailer(),
 				$this->newGetPaymentUseCase(),
 				adminEmailAddress: $this->config['contact-info']['admin']['email']
 			),
@@ -1248,18 +1244,33 @@ class FunFunFactory implements LoggerAwareInterface {
 		);
 	}
 
-	private function newApplyForMembershipMailer(): MembershipTemplateMailerInterface {
-		return $this->newErrorHandlingTemplateMailer(
-			$this->getMembershipMessenger(),
-			new TwigTemplate(
-				$this->getMailerTwig(),
-				'Membership_Application_Confirmation.txt.twig',
-				[ 'greeting_generator' => $this->getGreetingGenerator() ]
-			),
-			new MembershipConfirmationMailSubjectRenderer(
-				$this->getMailTranslator(),
-				'mail_subject_confirm_membership_application_active',
-				'mail_subject_confirm_membership_application_sustaining'
+	private function newApplyForMembershipMailer(): MembershipMailerAdapter {
+		return new MembershipMailerAdapter(
+			$this->newErrorHandlingTemplateMailer(
+					$this->getMembershipMessenger(),
+					new TwigTemplate(
+						$this->getMailerTwig(),
+						'Membership_Application_Confirmation.txt.twig',
+						[ 'greeting_generator' => $this->getGreetingGenerator() ]
+					),
+					new MembershipConfirmationMailSubjectRenderer(
+						$this->getMailTranslator(),
+						'mail_subject_confirm_membership_application_active',
+						'mail_subject_confirm_membership_application_sustaining'
+					)
+			)
+		);
+	}
+
+	private function newApplyForMembershipAdminMailer(): MembershipMailerAdapter {
+		return new MembershipMailerAdapter(
+			new ErrorHandlingMailerDecorator(
+				$this->newAdminMailer(
+					'ein Mitgliedschaftsantrag',
+					'https://backend.wikimedia.de/backend/member/list',
+					$this->getAdminMessenger()
+				),
+				$this->getLogger()
 			)
 		);
 	}

--- a/src/Infrastructure/Mail/ErrorHandlingMailerDecorator.php
+++ b/src/Infrastructure/Mail/ErrorHandlingMailerDecorator.php
@@ -7,12 +7,11 @@ namespace WMDE\Fundraising\Frontend\Infrastructure\Mail;
 use Psr\Log\LoggerInterface;
 use WMDE\EmailAddress\EmailAddress;
 use WMDE\Fundraising\DonationContext\Infrastructure\TemplateMailerInterface as DonationTemplateMailerInterface;
-use WMDE\Fundraising\MembershipContext\Infrastructure\TemplateMailerInterface as MembershipTemplateMailerInterface;
 
-class ErrorHandlingTemplateBasedMailer implements DonationTemplateMailerInterface, MembershipTemplateMailerInterface {
+class ErrorHandlingMailerDecorator implements DonationTemplateMailerInterface, TemplateMailerInterface {
 
 	public function __construct(
-		private readonly DonationTemplateMailerInterface|MembershipTemplateMailerInterface $templateBasedMailer,
+		private readonly TemplateMailerInterface $templateBasedMailer,
 		private readonly LoggerInterface $logger
 	) {
 	}

--- a/src/Infrastructure/Mail/MembershipMailerAdapter.php
+++ b/src/Infrastructure/Mail/MembershipMailerAdapter.php
@@ -1,0 +1,23 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure\Mail;
+
+use WMDE\EmailAddress\EmailAddress;
+use WMDE\Fundraising\MembershipContext\Infrastructure\TemplateMailerInterface as MembershipMailerInterface;
+use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\Notification\ApplyForMembershipTemplateArguments;
+
+/**
+ * This is an adapter class that converts the ApplyForMembershipTemplateArguments into an array
+ * that the {@see TemplateMailerInterface} can handle.
+ */
+class MembershipMailerAdapter implements MembershipMailerInterface {
+	public function __construct(
+		private readonly TemplateMailerInterface $templateMailer
+	) {
+	}
+
+	public function sendMail( EmailAddress $recipient, ApplyForMembershipTemplateArguments $templateArguments ): void {
+		$this->templateMailer->sendMail( $recipient, get_object_vars( $templateArguments ) );
+	}
+}

--- a/src/Infrastructure/Mail/NullMailer.php
+++ b/src/Infrastructure/Mail/NullMailer.php
@@ -5,9 +5,9 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\Infrastructure\Mail;
 
 use WMDE\EmailAddress\EmailAddress;
-use WMDE\Fundraising\DonationContext\Infrastructure\TemplateMailerInterface;
+use WMDE\Fundraising\DonationContext\Infrastructure\TemplateMailerInterface as DonationTemplateMailer;
 
-class NullMailer implements TemplateMailerInterface {
+class NullMailer implements DonationTemplateMailer, TemplateMailerInterface {
 
 	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ): void {
 		// Does nothing on purpose

--- a/src/Infrastructure/Mail/TemplateBasedMailer.php
+++ b/src/Infrastructure/Mail/TemplateBasedMailer.php
@@ -7,17 +7,16 @@ namespace WMDE\Fundraising\Frontend\Infrastructure\Mail;
 use WMDE\EmailAddress\EmailAddress;
 use WMDE\Fundraising\DonationContext\Infrastructure\TemplateMailerInterface as DonationTemplateMailerInterface;
 use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
-use WMDE\Fundraising\MembershipContext\Infrastructure\TemplateMailerInterface as MembershipTemplateMailerInterface;
 use WMDE\Fundraising\SubscriptionContext\Infrastructure\TemplateMailerInterface as SubscriptionTemplateMailerInterface;
 
 /**
- * @license GPL-2.0-or-later
+ * This is a class that sends e-mails with contents based on the Twig template passed in the constructor.
  */
 class TemplateBasedMailer implements
 	DonationTemplateMailerInterface,
-	MembershipTemplateMailerInterface,
 	SubscriptionTemplateMailerInterface,
-	GetInTouchMailerInterface
+	GetInTouchMailerInterface,
+	TemplateMailerInterface
 {
 
 	private Messenger $messenger;
@@ -30,10 +29,6 @@ class TemplateBasedMailer implements
 		$this->subjectRenderer = $subjectRenderer;
 	}
 
-	/**
-	 * @inheritDoc
-	 * @throws \RuntimeException
-	 */
 	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ): void {
 		$this->messenger->sendMessageToUser(
 			new Message(

--- a/src/Infrastructure/Mail/TemplateMailerInterface.php
+++ b/src/Infrastructure/Mail/TemplateMailerInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure\Mail;
+
+use WMDE\EmailAddress\EmailAddress;
+
+/**
+ * This is an interface that enables the different wrappers for
+ */
+interface TemplateMailerInterface {
+	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ): void;
+}

--- a/tests/Fixtures/ErrorThrowingTemplateBasedMailer.php
+++ b/tests/Fixtures/ErrorThrowingTemplateBasedMailer.php
@@ -6,9 +6,9 @@ namespace WMDE\Fundraising\Frontend\Tests\Fixtures;
 
 use WMDE\EmailAddress\EmailAddress;
 use WMDE\Fundraising\DonationContext\Infrastructure\TemplateMailerInterface as DonationTemplateMailerInterface;
-use WMDE\Fundraising\MembershipContext\Infrastructure\TemplateMailerInterface as MembershipTemplateMailerInterface;
+use WMDE\Fundraising\Frontend\Infrastructure\Mail\TemplateMailerInterface;
 
-class ErrorThrowingTemplateBasedMailer implements DonationTemplateMailerInterface, MembershipTemplateMailerInterface {
+class ErrorThrowingTemplateBasedMailer implements DonationTemplateMailerInterface, TemplateMailerInterface {
 
 	private ?\Throwable $previous;
 

--- a/tests/Fixtures/TemplateBasedMailerSpy.php
+++ b/tests/Fixtures/TemplateBasedMailerSpy.php
@@ -8,11 +8,12 @@ use PHPUnit\Framework\TestCase;
 use WMDE\EmailAddress\EmailAddress;
 use WMDE\Fundraising\DonationContext\Infrastructure\TemplateMailerInterface as DonationTemplateMailerInterface;
 use WMDE\Fundraising\Frontend\Infrastructure\Mail\GetInTouchMailerInterface;
+use WMDE\Fundraising\Frontend\Infrastructure\Mail\TemplateMailerInterface;
 
 /**
  * @license GPL-2.0-or-later
  */
-class TemplateBasedMailerSpy implements GetInTouchMailerInterface, DonationTemplateMailerInterface {
+class TemplateBasedMailerSpy implements GetInTouchMailerInterface, DonationTemplateMailerInterface, TemplateMailerInterface {
 
 	private TestCase $testCase;
 	/**

--- a/tests/Unit/Infrastructure/Mail/ErrorHandlingMailerDecoratorTest.php
+++ b/tests/Unit/Infrastructure/Mail/ErrorHandlingMailerDecoratorTest.php
@@ -7,15 +7,15 @@ namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure\Mail;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use WMDE\EmailAddress\EmailAddress;
-use WMDE\Fundraising\Frontend\Infrastructure\Mail\ErrorHandlingTemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\Mail\ErrorHandlingMailerDecorator;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\ErrorThrowingTemplateBasedMailer;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\TemplateBasedMailerSpy;
 use WMDE\PsrLogTestDoubles\LoggerSpy;
 
 /**
- * @covers \WMDE\Fundraising\Frontend\Infrastructure\Mail\ErrorHandlingTemplateBasedMailer
+ * @covers \WMDE\Fundraising\Frontend\Infrastructure\Mail\ErrorHandlingMailerDecorator
  */
-class ErrorHandlingTemplateBasedMailerTest extends TestCase {
+class ErrorHandlingMailerDecoratorTest extends TestCase {
 
 	public function testOnSendMail_sendsMail(): void {
 		$mailerSpy = new TemplateBasedMailerSpy( $this );
@@ -23,7 +23,7 @@ class ErrorHandlingTemplateBasedMailerTest extends TestCase {
 		$email = new EmailAddress( 'happy@bunny.carrot' );
 		$arguments = [ 'gotta get up' => 'to get down' ];
 
-		$errorHandlingMailer = new ErrorHandlingTemplateBasedMailer(
+		$errorHandlingMailer = new ErrorHandlingMailerDecorator(
 			$mailerSpy,
 			$loggerSpy
 		);
@@ -37,7 +37,7 @@ class ErrorHandlingTemplateBasedMailerTest extends TestCase {
 	public function testOnSendMailWithError_logsError(): void {
 		$loggerSpy = new LoggerSpy();
 
-		$errorHandlingMailer = new ErrorHandlingTemplateBasedMailer(
+		$errorHandlingMailer = new ErrorHandlingMailerDecorator(
 			new ErrorThrowingTemplateBasedMailer(),
 			$loggerSpy
 		);
@@ -52,7 +52,7 @@ class ErrorHandlingTemplateBasedMailerTest extends TestCase {
 	public function testItLogsPreviousException(): void {
 		$loggerSpy = new LoggerSpy();
 
-		$errorHandlingMailer = new ErrorHandlingTemplateBasedMailer(
+		$errorHandlingMailer = new ErrorHandlingMailerDecorator(
 			new ErrorThrowingTemplateBasedMailer( new \RuntimeException( 'Transport error - The mule ran away' ) ),
 			$loggerSpy
 		);

--- a/tests/Unit/Infrastructure/Mail/MembershipMailerAdapterTest.php
+++ b/tests/Unit/Infrastructure/Mail/MembershipMailerAdapterTest.php
@@ -1,0 +1,54 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure\Mail;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\EmailAddress\EmailAddress;
+use WMDE\Fundraising\Frontend\Infrastructure\Mail\MembershipMailerAdapter;
+use WMDE\Fundraising\Frontend\Tests\Fixtures\TemplateBasedMailerSpy;
+use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\Notification\ApplyForMembershipTemplateArguments;
+
+/**
+ * @covers \WMDE\Fundraising\Frontend\Infrastructure\Mail\MembershipMailerAdapter
+ */
+class MembershipMailerAdapterTest extends TestCase {
+	public function testAdapterConvertsObjectPropertiesToArray(): void {
+		$mailerSpy = new TemplateBasedMailerSpy( $this );
+		$adapter = new MembershipMailerAdapter( $mailerSpy );
+		$emailAddress = new EmailAddress( 'musterfrau@beispiel.de' );
+		$templateDTO = new ApplyForMembershipTemplateArguments(
+			id: 1,
+			membershipType: 'sustaining',
+			membershipFee: '12.00',
+			membershipFeeInCents: 1200,
+			paymentIntervalInMonths: 1,
+			paymentType: 'BEZ',
+			salutation: 'Frau',
+			title: 'Dr.',
+			lastName: 'Musterfrau',
+			firstName: 'Annika',
+			hasReceiptEnabled: true,
+			incentives: [],
+			moderationFlags: []
+		);
+
+		$adapter->sendMail( $emailAddress, $templateDTO );
+
+		$mailerSpy->assertCalledOnceWith( $emailAddress, [
+			'id' => 1,
+			'membershipType' => 'sustaining',
+			'membershipFee' => '12.00',
+			'membershipFeeInCents' => 1200,
+			'paymentIntervalInMonths' => 1,
+			'paymentType' => 'BEZ',
+			'salutation' => 'Frau',
+			'title' => 'Dr.',
+			'lastName' => 'Musterfrau',
+			'firstName' => 'Annika',
+			'hasReceiptEnabled' => true,
+			'incentives' => [],
+			'moderationFlags' => []
+		] );
+	}
+}


### PR DESCRIPTION
The new confirmation mailer of the membership bounded context now passes
class-based parameters, breaking the "unified" `sendMail` interface that
exists across bounded contexts. This change splits the mailer into two
parts - the TemplateMailerInterface that all Twig-based mailers and
their decorators implement and an adapter, that converts the membership
mailer into the TemplateMailerInterface.

This is a "template" for possible changes to the mailers in all bounded
context - they will probably also switch from arrays to value objects,
getting their own adapters.

Ticket: https://phabricator.wikimedia.org/T359803
