### PR TITLE
Add ability to run the Drone CI pipeline locally

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,8 +26,17 @@ steps:
       - php bin/console app:validate:config app/config/config.dist.json app/config/config.test.json
       - php bin/console app:validate:config app/config/config.dist.json .docker/app/config.dev.json
       - php bin/console app:validate:campaigns dev
+
+  - name: upload-coverage
+    image: registry.gitlab.com/fun-tech/fundraising-frontend-docker:ci
+    environment:
+    commands:
       # Upload coverage to Scrutinizer
       - ocular code-coverage:upload --no-interaction --format=php-clover coverage.xml
+    when:
+      event:
+        - push
+        - pull_request
 
 volumes:
   - name: cache

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 composer.phar
 npm-debug.log
 coverage.clover
+coverage.xml
 
 vendor/
 node_modules/

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ drone-ci:
 	-@drone exec --secret-file var/.drone-secrets.txt --trusted .drone.yml ; \
 	RET=$$?; \
 	rm -f var/.drone-secrets.txt; \
-	if [ $$RET -eq 0 ]; then echo -e "\033[0;32mDrone CI passed\033[0m"; else echo -e "\033[0;31mDrone CI failed\033[0m"; fi; \
+	if [ $$RET -eq 0 ]; then echo "\n\n\033[0;32mDrone CI passed\033[0m\n\n"; else echo "\n\n\033[0;31mDrone CI failed\033[0m\n\n"; fi; \
 	exit $$RET
 
 # Installation

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ DOCKER_IMAGE  := registry.gitlab.com/fun-tech/fundraising-frontend-docker
 
 .DEFAULT_GOAL := ci
 
+# Local Development Environment
+
 up-app: down-app validate-dev-config
 	docker-compose -f docker-compose.yml up -d
 
@@ -32,6 +34,16 @@ ifeq ($(wildcard app/config/paypal_api.dev.yml),)
 	$(error File 'app/config/paypal_api.dev.yml' does not exist. Please run 'make default-config')
 endif
 	docker-compose run --rm --no-deps app ./bin/console app:validate:config app/config/config.dist.json app/config/config.dev.json
+
+# This needs the "drone" and "pass" cli tools to be installed on or local machine
+drone-ci:
+	@echo -n "GITHUB_TOKEN=" > var/.drone-secrets.txt
+	@pass wmde-fun/github-composer-ci-token >> var/.drone-secrets.txt
+	-@drone exec --secret-file var/.drone-secrets.txt --trusted .drone.yml ; \
+	RET=$$?; \
+	rm -f var/.drone-secrets.txt; \
+	if [ $$RET -eq 0 ]; then echo -e "\033[0;32mDrone CI passed\033[0m"; else echo -e "\033[0;31mDrone CI failed\033[0m"; fi; \
+	exit $$RET
 
 # Installation
 

--- a/doc/HOWTO_Run_Drone_Locally.md
+++ b/doc/HOWTO_Run_Drone_Locally.md
@@ -1,0 +1,22 @@
+# How to run the DRONE CI pipeline on your local machine
+
+## Prerequisites
+
+You need to have the `drone` command line interface installed on your
+local machine. See https://docs.drone.io/cli/install/ for download links
+and installation instructions.
+
+You need to have the `pass` password manager installed, configured and be
+able to access the Fundraising Tech password repository. You can try out
+your setup by running `pass wmde-fun/github-composer-ci-token`. After
+entering your GPG password you should then see the GitHub token.
+
+As the last item on the list, you should be able to use `docker` commands
+on your local machine.
+
+## Running Drone CI pipeline on your local machine
+
+
+    make drone-ci
+
+


### PR DESCRIPTION
Moved upload of coverage information to Scrutinizer into a separate step
that Drone will only execute for branch pushes and pull requests.
