### PR TITLE
Ignore errors in `make fix-cs`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ cs:
 	docker-compose run --rm --no-deps app ./vendor/bin/phpcs
 
 fix-cs:
-	docker-compose run --rm --no-deps app ./vendor/bin/phpcbf
+	-docker-compose run --rm --no-deps app ./vendor/bin/phpcbf
 
 stan:
 	docker run --rm -it --volume $(BUILD_DIR):/app -w /app $(DOCKER_IMAGE):dev php -d memory_limit=1G vendor/bin/phpstan analyse --level=5 --no-progress cli/ src/ tests/


### PR DESCRIPTION
With this change you can prepend any other task with the `fix-cs` prefix
and Make will run the task even when fix-cs fixed your code.

Run

    make fix-cs ci

to fix your code before doing a full CI run.
