### PR TITLE
Add individual page titles to the templates

### DIFF
--- a/skins/laika/templates/Access_Denied.twig
+++ b/skins/laika/templates/Access_Denied.twig
@@ -1,10 +1,12 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'access_denied_page_title' ) $}{% endblock %}
+
 {% block main %}
     <div id="app">
         <noscript>
             <h2>{$ site_metadata.access_denied_header $}</h2>
-            <p>{$ message | default( site_metadata.access_denied ) | raw $}<p>
+            <p>{$ message | default( site_metadata.access_denied ) | raw $}</p>
         </noscript>
     </div>
     <div id="appdata"

--- a/skins/laika/templates/AddressUpdateSuccess.html.twig
+++ b/skins/laika/templates/AddressUpdateSuccess.html.twig
@@ -1,5 +1,7 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'address_update_success_page_title' ) $}{% endblock %}
+
 {% block scripts %}
     {$ parent() $}
     <script src="{$ asset( 'js/address_update_success.js', 'skin' ) $}"></script>

--- a/skins/laika/templates/Comment_List.html.twig
+++ b/skins/laika/templates/Comment_List.html.twig
@@ -1,5 +1,7 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'comment_list_page_title' ) $}{% endblock %}
+
 {% block scripts %}
 	{$ parent() $}
 	<script src="{$ asset( 'js/comment_list.js', 'skin' ) $}"></script>

--- a/skins/laika/templates/Comment_Ticker.html.twig
+++ b/skins/laika/templates/Comment_Ticker.html.twig
@@ -1,5 +1,7 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'comment_ticker_page_title' ) $}{% endblock %}
+
 {% block scripts %}
 	{$ parent() $}
 	<script src="{$ asset( 'js/comment_ticker.js', 'skin' ) $}"></script>

--- a/skins/laika/templates/Contact_Form.html.twig
+++ b/skins/laika/templates/Contact_Form.html.twig
@@ -1,5 +1,7 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'contact_form_page_title' ) $}{% endblock %}
+
 {% block scripts %}
 	{$ parent() $}
 	<script src="{$ asset( 'js/contact_form.js', 'skin' ) $}"></script>

--- a/skins/laika/templates/Donation_Confirmation.html.twig
+++ b/skins/laika/templates/Donation_Confirmation.html.twig
@@ -1,5 +1,7 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'donation_confirmation_page_title' ) $}{% endblock %}
+
 {% block scripts %}
 	{$ parent() $}
 	<script src="{$ asset( 'js/donation_confirmation.js', 'skin' ) $}"></script>

--- a/skins/laika/templates/Donation_Form.html.twig
+++ b/skins/laika/templates/Donation_Form.html.twig
@@ -1,5 +1,7 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'donation_form_page_title' ) $}{% endblock %}
+
 {% block scripts %}
 	{$ parent() $}
 	<script src="{$ asset( 'js/donation_form.js', 'skin' ) $}"></script>

--- a/skins/laika/templates/Error_Page.html.twig
+++ b/skins/laika/templates/Error_Page.html.twig
@@ -1,5 +1,7 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'error_page_title' ) $}{% endblock %}
+
 {% block scripts %}
 	{$ parent() $}
 	<script src="{$ asset( 'js/error.js', 'skin' ) $}"></script>

--- a/skins/laika/templates/Frequent_Questions.html.twig
+++ b/skins/laika/templates/Frequent_Questions.html.twig
@@ -1,5 +1,7 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'faq_page_title' ) $}{% endblock %}
+
 {% block scripts %}
 	{$ parent() $}
 	<script src="{$ asset( 'js/frequent_questions.js', 'skin' ) $}"></script>

--- a/skins/laika/templates/Funds_Usage.html.twig
+++ b/skins/laika/templates/Funds_Usage.html.twig
@@ -1,5 +1,7 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'use_of_funds_page_title' ) $}{% endblock %}
+
 {% block scripts %}
     {$ parent() $}
     <script src="{$ asset( 'js/funds_usage.js', 'skin' ) $}"></script>

--- a/skins/laika/templates/Membership_Application.html.twig
+++ b/skins/laika/templates/Membership_Application.html.twig
@@ -1,5 +1,7 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'membership_application_page_title' ) $}{% endblock %}
+
 {% block scripts %}
 	{$ parent() $}
 	<script src="{$ asset( 'js/membership_application.js', 'skin' ) $}"></script>

--- a/skins/laika/templates/Membership_Application_Confirmation.html.twig
+++ b/skins/laika/templates/Membership_Application_Confirmation.html.twig
@@ -1,5 +1,7 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'membership_application_confirmation_page_title' ) $}{% endblock %}
+
 {% block scripts %}
 	{$ parent() $}
 	<script src="{$ asset( 'js/membership_application_confirmation.js', 'skin' ) $}"></script>

--- a/skins/laika/templates/Page_Not_Found.html.twig
+++ b/skins/laika/templates/Page_Not_Found.html.twig
@@ -1,10 +1,12 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'page_not_found_page_title' ) $}{% endblock %}
+
 {% block main %}
 	<div id="app">
 		<noscript>
 			<h2>{$ site_metadata.page_not_found_header $}</h2>
-			<p>{$ site_metadata.page_not_found | raw $}<p>
+			<p>{$ site_metadata.page_not_found | raw $}</p>
 		</noscript>
 	</div>
 	<div id="appdata"

--- a/skins/laika/templates/Subscription_Confirmation.twig
+++ b/skins/laika/templates/Subscription_Confirmation.twig
@@ -1,5 +1,7 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'subscription_confirmation_page_title' ) $}{% endblock %}
+
 {% block scripts %}
     {$ parent() $}
     <script src="{$ asset( 'js/subscription_confirmation.js', 'skin' ) $}"></script>

--- a/skins/laika/templates/System_Message.html.twig
+++ b/skins/laika/templates/System_Message.html.twig
@@ -1,5 +1,7 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'system_message_page_title' ) $}{% endblock %}
+
 {% block scripts %}
 	{$ parent() $}
 	<script src="{$ asset( 'js/system_message.js', 'skin' ) $}"></script>

--- a/skins/laika/templates/Update_Address.html.twig
+++ b/skins/laika/templates/Update_Address.html.twig
@@ -1,5 +1,7 @@
 {% extends 'Base_Layout.html.twig' %}
 
+{% block title %}{$ page_title( 'update_address_page_title' ) $}{% endblock %}
+
 {% block scripts %}
 	{$ parent() $}
 	<script src="{$ asset( 'js/update_address.js', 'skin' ) $}"></script>

--- a/skins/laika/templates/page_layouts/base.html.twig
+++ b/skins/laika/templates/page_layouts/base.html.twig
@@ -3,6 +3,8 @@
 {% set title = site_metadata.page_titles[page_id] %}
 {% set content = web_content("pages/#{page_id}") %}
 
+{% block title %}{$ page_title( page_id ) $}{% endblock %}
+
 {% block main %}
 	<div id="app">
 		<noscript>

--- a/skins/laika/templates/page_layouts/supporters.html.twig
+++ b/skins/laika/templates/page_layouts/supporters.html.twig
@@ -1,6 +1,8 @@
 {% extends 'Base_Layout.html.twig' %}
 {% set title = site_metadata.page_titles[page_id] %}
 
+{% block title %}{$ page_title( page_id ) $}{% endblock %}
+
 {% block scripts %}
 	{$ parent() $}
 	<script src="{$ asset( 'js/supporters.js', 'skin' ) $}"></script>

--- a/src/Factories/WebTemplatingFactory.php
+++ b/src/Factories/WebTemplatingFactory.php
@@ -46,6 +46,14 @@ class WebTemplatingFactory extends TwigFactory {
 				},
 				[ 'is_safe' => [ 'html' ] ]
 			),
+			new TwigFunction(
+				'page_title',
+				function ( string $key ): string {
+					$title = $this->translations[ 'site_name' ] ?? '';
+					return str_replace( '{pageTitle}', $this->translations[ $key ] ?? '', $title );
+				},
+				[ 'is_safe' => [ 'html' ] ]
+			),
 		];
 	}
 


### PR DESCRIPTION
Adds the page titles into the page templates to remove the title content flash that was happening on page load.

It does this by adding a page title function to Twig.

Ticket: https://phabricator.wikimedia.org/T362630