### PR TITLE
Add modal target element to base layout

### DIFF
--- a/skins/laika/templates/Base_Layout.html.twig
+++ b/skins/laika/templates/Base_Layout.html.twig
@@ -59,6 +59,7 @@
             </div>
         {% endif %}
     </div>
+    <div id="modal-target"></div>
     <div
         id="appdata"
         data-application-vars="{$ _context|json_encode|e('html_attr') $}"


### PR DESCRIPTION
Modals need to be displayed outside the main vue app
element, so that when opened the app can be marked as
inert to prevent the donor tabbing to it.

Ticket: https://phabricator.wikimedia.org/T361818