### PR TITLE
Fix overriding application config in tests

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -97,10 +97,6 @@ services:
         class: WMDE\Fundraising\Frontend\Infrastructure\EventHandling\DomainEventHandler\BucketLoggingHandler
         factory: ['@WMDE\Fundraising\Frontend\Factories\FunFunFactory', 'getBucketLoggingHandler']
 
-    WMDE\Fundraising\Frontend\Infrastructure\SkinCacheWarmer:
-        class: WMDE\Fundraising\Frontend\Infrastructure\SkinCacheWarmer
-        tags:
-            - { name: kernel.cache_warmer }
 
     app.errbit_logger:
         class: Airbrake\MonologHandler

--- a/config/services_prod.yml
+++ b/config/services_prod.yml
@@ -1,0 +1,5 @@
+services:
+  WMDE\Fundraising\Frontend\Infrastructure\SkinCacheWarmer:
+    class: WMDE\Fundraising\Frontend\Infrastructure\SkinCacheWarmer
+    tags:
+      - { name: kernel.cache_warmer }

--- a/tests/EdgeToEdge/WebRouteTestCase.php
+++ b/tests/EdgeToEdge/WebRouteTestCase.php
@@ -137,6 +137,11 @@ abstract class WebRouteTestCase extends KernelTestCase {
 	 * @return KernelInterface
 	 */
 	protected static function bootKernel( array $options = [] ): KernelInterface {
+		// `bootKernel` initializes all Symfony dependencies. If any of those depends on the FunFunFactory,
+		// overriding the configuration will break because by the time we call `static::getFactory`,
+		// it will already be initialized (with the unmodified configuration).
+		// A stopgap solution is to move those services into `services_prod.yml`.
+		// A better solution would be to make those services independent of FunFunFactory.
 		$kernel = parent::bootKernel( $options );
 
 		self::modifyBootstrapperConfiguration();


### PR DESCRIPTION
While running `ShowUpdateAddressFormRouteTest` individually, I ran into
the bug that one test was failing (because a template file was not
present in `skins/test` but was is present in `skins/laika`), but only
when I did run it individually, not when running `make test`. The
cause of this was as follows:

`WebRouteTestCase` calls `bootKernel` which initializes all Symfony
dependencies. One of those dependencies is the `SkinCacheWarmer`, which
has `FunFunFactory` as a dependency, creating a Twig instance. This
dependency causes Symfony to initialize `FunFunFactory` with the default
configuration for the test environment, using `test` as the skin name.
The mechanism of `WebRouteTestCase` for overriding the configuration
passed to `FunFunFactory` assumes that the `bootKernel` method won't
initialize `FunFunFactory`.

The "temporary" solution is to move the cache warmer out of the testing
dependencies and into the production dependencies.

A better solution would be to initialize it without the `FunFunFactory`,
but the Twig environment has a lot of other dependencies that we'd have
to move out of the `FunFunFactory` and into `services.yml` that we'll
probably live with the current solution for some time.

Another solution would be change how we override the skin name.

When we've either changed the application to provide API for a single
page application (Ticket https://phabricator.wikimedia.org/T241751 ) or
removed the dependency of our tests on the `test` skin
(Ticket https://phabricator.wikimedia.org/T241751 ) we can move the
cache warming service back into `services.yml` because the default
skin in the configuration won't need overrides in the tests.
