### PR TITLE
Update to docker compose V2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MIGRATION_VERSION :=
 MIGRATION_CONTEXT :=
 APP_ENV       := dev
 ASSET_BRANCH  := main
-DOCTRINE_SCHEMA_COMMAND := docker-compose run --rm app ./bin/doctrine orm:schema-tool:create --dump-sql | sed 's/The following SQL statements will be executed://; s/CREATE TABLE/CREATE TABLE IF NOT EXISTS/'
+DOCTRINE_SCHEMA_COMMAND := docker compose run --rm app ./bin/doctrine orm:schema-tool:create --dump-sql | sed 's/The following SQL statements will be executed://; s/CREATE TABLE/CREATE TABLE IF NOT EXISTS/'
 
 DOCKER_IMAGE  := registry.gitlab.com/fun-tech/fundraising-frontend-docker
 
@@ -19,10 +19,10 @@ DOCKER_IMAGE  := registry.gitlab.com/fun-tech/fundraising-frontend-docker
 # Local Development Environment
 
 up-app: down-app validate-dev-config
-	docker-compose up -d
+	docker compose up -d
 
 down-app:
-	docker-compose down > /dev/null 2>&1
+	docker compose down > /dev/null 2>&1
 
 validate-dev-config:
 ifeq ($(wildcard app/config/config.dev.json),)
@@ -31,7 +31,7 @@ endif
 ifeq ($(wildcard app/config/paypal_api.dev.yml),)
 	$(error File 'app/config/paypal_api.dev.yml' does not exist. Please run 'make default-config')
 endif
-	docker-compose run --rm --no-deps app ./bin/console app:validate:config app/config/config.dist.json app/config/config.dev.json
+	docker compose run --rm --no-deps app ./bin/console app:validate:config app/config/config.dist.json app/config/config.dev.json
 
 # This needs the "drone" and "pass" cli tools to be installed on or local machine
 drone-ci:
@@ -71,11 +71,11 @@ validate-sql:
 	$(DOCTRINE_SCHEMA_COMMAND) | diff - ./.docker/database/01.Database_Schema.sql 1>&2
 
 setup-doctrine:
-	docker-compose run --rm start_dependencies
-	docker-compose run --rm app ./bin/doctrine orm:generate-proxies var/doctrine_proxies
+	docker compose run --rm start_dependencies
+	docker compose run --rm app ./bin/doctrine orm:generate-proxies var/doctrine_proxies
 
 drop-db:
-	docker-compose run --rm app ./bin/doctrine orm:schema-tool:drop --force
+	docker compose run --rm app ./bin/doctrine orm:schema-tool:drop --force
 
 download-assets:
 	./bin/download_assets.sh $(ASSET_BRANCH)
@@ -83,8 +83,8 @@ download-assets:
 # Maintenance
 
 clear:
-	docker-compose exec app sh -c "rm -rf /tmp/symfony/cache/*"
-	docker-compose exec app chown -R www-data:www-data /tmp/symfony
+	docker compose exec app sh -c "rm -rf /tmp/symfony/cache/*"
+	docker compose exec app chown -R www-data:www-data /tmp/symfony
 
 # an alias to avoid frequent typo
 clean: clear
@@ -96,44 +96,44 @@ ci: phpunit cs validate-app-config validate-campaign-config stan lint-container
 ci-with-coverage: phpunit-with-coverage cs validate-app-config validate-campaign-config stan lint-container
 
 phpunit-system:
-	docker-compose run --rm --no-deps app ./vendor/bin/phpunit tests/System/
+	docker compose run --rm --no-deps app ./vendor/bin/phpunit tests/System/
 
 lint-container:
-	docker-compose run --rm --no-deps app ./bin/console lint:container
+	docker compose run --rm --no-deps app ./bin/console lint:container
 
 validate-app-config:
-	docker-compose run --rm --no-deps app ./bin/console app:validate:config app/config/config.dist.json app/config/config.test.json
-	docker-compose run --rm --no-deps app ./bin/console app:validate:config app/config/config.dist.json .docker/app/config.dev.json
+	docker compose run --rm --no-deps app ./bin/console app:validate:config app/config/config.dist.json app/config/config.test.json
+	docker compose run --rm --no-deps app ./bin/console app:validate:config app/config/config.dist.json .docker/app/config.dev.json
 
 validate-campaign-config:
-	docker-compose run --rm --no-deps app ./bin/console app:validate:campaigns $(APP_ENV)
+	docker compose run --rm --no-deps app ./bin/console app:validate:campaigns $(APP_ENV)
 
 validate-campaign-utilization:
-	docker-compose run --rm --no-deps app ./bin/console app:validate:campaigns:utilization
+	docker compose run --rm --no-deps app ./bin/console app:validate:campaigns:utilization
 
 # Code Quality
 
 test: phpunit
 
 phpunit:
-	docker-compose run --rm --no-deps app php -d memory_limit=1G vendor/bin/phpunit $(TEST_DIR)
+	docker compose run --rm --no-deps app php -d memory_limit=1G vendor/bin/phpunit $(TEST_DIR)
 
 phpunit-with-coverage:
-	docker-compose \
+	docker compose \
 		run --rm --no-deps app \
 		php -d memory_limit=1G -d xdebug.mode=coverage \
 		vendor/bin/phpunit --configuration=phpunit.xml.dist --stop-on-error $(COVERAGE_FLAGS)
 
 cs:
-	docker-compose run --rm --no-deps app ./vendor/bin/phpcs
+	docker compose run --rm --no-deps app ./vendor/bin/phpcs
 
 fix-cs:
-	-docker-compose run --rm --no-deps app ./vendor/bin/phpcbf
+	-docker compose run --rm --no-deps app ./vendor/bin/phpcbf
 
 stan:
 	docker run --rm -it --volume $(BUILD_DIR):/app -w /app $(DOCKER_IMAGE):latest php -d memory_limit=1G vendor/bin/phpstan analyse --level=9 --no-progress cli/ src/ tests/
 
 phpmd:
-	docker-compose run --rm --no-deps app ./vendor/bin/phpmd src/ text phpmd.xml
+	docker compose run --rm --no-deps app ./vendor/bin/phpmd src/ text phpmd.xml
 
 .PHONY: up-app down-app setup create-env download-assets install-php update-php generate-database-schema validate-sql setup-doctrine drop-db default-config clear clean ui test ci ci-with-coverage phpunit phpunit-with-coverage phpunit-system cs fix-cs stan validate-app-config validate-campaign-config validate-campaign-utilization lint-container phpmd

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ markdown-toc --maxdepth 2 --bullets '*' -i README.md
 
 ### First setup
 
-For development, you need to have Docker and docker-compose installed. You need at least Docker Version >= 17.09.0 and docker-compose version >= 1.17.0. If your OS does not come with the right version, please use the official installation instructions for [Docker](https://docs.docker.com/install/) and [docker-compose](https://docs.docker.com/compose/install/). You don't need to install other dependencies (PHP, Node.js, MariaDB) on your machine.
+For development, you need to have Docker and docker compose installed. You need at least Docker version >= 20 and the docker compose plugin (compose version >= 2). If your OS does not come with the right version, please use the official installation instructions for [Docker](https://docs.docker.com/install/). You don't need to install other dependencies (PHP, Node.js, MariaDB) on your machine.
 
 Get a clone of our git repository and then run:
 
@@ -68,7 +68,7 @@ To stop the application, run
 The `up-app` task will also make sure that your local configuration is correct and will stop previous instances of the application.
 You can run the application without the Makefile, in the foreground, with the command
 
-    docker-compose up
+    docker compose up
 
 ## Configuration
 
@@ -168,11 +168,11 @@ campaign configuration files on top of each other.
 
 ### Running in different environments
 By default, the configuration environment is `dev` and the configuration file is `config.dev.json`. If you want to
-change that, you have to pass the environment variable to `make`, `docker` and `docker-compose` commands.
+change that, you have to pass the environment variable to `make`, `docker` and `docker compose` commands.
 
     make ci APP_ENV=prod
 
-For `docker-compose` you can create a file called `.env` in the application directory with the contents of
+For `docker compose` you can create a file called `.env` in the application directory with the contents of
 
     APP_ENV=prod
 
@@ -253,7 +253,7 @@ To drop the database and rebuild it from scratch the database, you need to stop 
 
 You can shut down all containers and delete all volumes with the command
 
-    docker-compose down -v
+    docker compose down -v
 
 The next time you run `make up-app`, the database container will
 process all SQL files in [.docker/database](.docker/database).
@@ -262,8 +262,8 @@ process all SQL files in [.docker/database](.docker/database).
 
 To start the command line client, use the following commands:
 
-    docker-compose up -d database
-    docker-compose exec database mysql -u fundraising -p"INSECURE PASSWORD" fundraising
+    docker compose up -d database
+    docker compose exec database mysql -u fundraising -p"INSECURE PASSWORD" fundraising
 
 ### Accessing the database from your host machine
 
@@ -299,11 +299,11 @@ documentation mentions running the command
 E.g. `bin/doctrine migrations:status`.
 
 In your Docker-based development environment, run the command in the `app`
-container, using `docker-compose exec`. The container environment must be
+container, using `docker compose exec`. The container environment must be
 running for this to work. Example:
 
 ```
-docker-compose exec app bin/doctrine migrations:status
+docker compose exec app bin/doctrine migrations:status
 ```
 
 #### Running migrations on the server
@@ -344,7 +344,7 @@ Copy the full network name and container name and use them instead of the placeh
 To import the German postcode database, you need to place it in
 `.docker/database/00.postcodes.sql`. The database container will pick it up
 when running for the first time (when it creates the volume `db-storage`).
-This happens when you run `docker-compose up` for the first time or when
+This happens when you run `docker compose up` for the first time or when
 you reset the database (see above). Depending on the speed of you machine,
 the import will take up to 10 minutes. Watch the output of the
 `database` container so see when the database has finished importing.
@@ -409,7 +409,7 @@ same cache location inside the container - `/tmp/symfony`. When running
 CLI commands, the owner of the files will be `root:root`. This will
 prevent the PHP-FPM process from writing to the cache. If you get a
 cache-related error in your browser, run the following command while the
-docker-compose environment is running:
+docker compose environment is running:
 
     make clear
 

--- a/doc/Email_Templates.md
+++ b/doc/Email_Templates.md
@@ -27,12 +27,12 @@ Because the generated templates have been just created, these tests will then pa
 
 The directory `tests/data/GeneratedMailTemplates` contains the rendered templates, but without the actual content from the content repository. If you want to render the templates with actual content, you can use the `bin/console app:dump-mail-templates` command. It uses the same Fixtures as the `MailTemplatesTest` to generate the templates, but it also uses the actual content from the content repository and renders the templates with it. You can run `make update-php COMPOSER_FLAGS=wmde/fundraising-frontend-content` to update the content repository before running the command.
 
-Example command (using docker-compose):
+Example command (using `docker compose`):
 
 ```bash
-docker-compose exec app bin/console app:dump-mail-templates --locale=en_GB
+docker compose exec app bin/console app:dump-mail-templates --locale=en_GB
 ```
 By default, the templates will get rendered into the directory `rendered-mail-templates` in the application root. You can change the output directory with the `--output-path` option.
 
-If you're using `docker-compose` to run the command, the generated files and folders will have the wrong owner (`root`). You can fix this by running `sudo chown -R $USER:$USER rendered-mail-templates` in the application root.
+If you're using `docker compose` to run the command, the generated files and folders will have the wrong owner (`root`). You can fix this by running `sudo chown -R $USER:$USER rendered-mail-templates` in the application root.
 

--- a/doc/HOWTO_Import_Geodata.md
+++ b/doc/HOWTO_Import_Geodata.md
@@ -9,4 +9,4 @@ The Geodata zip contains 2 sql files, a small one with community names, and a la
    ```$ docker volume rm APP_DIRECTORY_db-storage```
    
    APP_DIRECTORY is the directory name where you have checked out the `fundraising-application` code. You can check for the volume name by listing all docker volumes with the command `$ docker volume ls`.
-4. Run `$ docker-compose up`. When importing the Geotata this might take several minutes as it imports.
+4. Run `$ docker compose up`. When importing the Geotata this might take several minutes as it imports.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   proxy:
     image: nginx:stable


### PR DESCRIPTION
- Replace commands in Makefile and documentation
- Remove "version" property from `docker-compose.yml` to avoid warnings.

Ticket: https://phabricator.wikimedia.org/T317957