### PR TITLE
Upgrade donations to 21.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6573,16 +6573,16 @@
         },
         {
             "name": "wmde/fundraising-donations",
-            "version": "V21.1.0",
+            "version": "v21.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-donations",
-                "reference": "4b2c1b2b94f40de8d24e53ffc8363b7251af26f6"
+                "reference": "4474ef55bc4bed8cc76b3d4921a28ed311f41169"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-donations/zipball/4b2c1b2b94f40de8d24e53ffc8363b7251af26f6",
-                "reference": "4b2c1b2b94f40de8d24e53ffc8363b7251af26f6",
+                "url": "https://api.github.com/repos/wmde/fundraising-donations/zipball/4474ef55bc4bed8cc76b3d4921a28ed311f41169",
+                "reference": "4474ef55bc4bed8cc76b3d4921a28ed311f41169",
                 "shasum": ""
             },
             "require": {
@@ -6631,7 +6631,7 @@
             ],
             "description": "Bounded Context for the Wikimedia Deutschland fundraising donation subdomain",
             "homepage": "https://github.com/wmde/fundraising-donations",
-            "time": "2024-09-02T16:07:52+00:00"
+            "time": "2024-09-26T12:55:51+00:00"
         },
         {
             "name": "wmde/fundraising-memberships",


### PR DESCRIPTION
The new version has more detailed error messages that will allow us to
debug a PayPal booking error in production.

Ticket: https://phabricator.wikimedia.org/T375196
