### PR TITLE
Avoid errors when getting PayPal notifications

### DIFF
--- a/app/Controllers/Payment/PaypalNotificationController.php
+++ b/app/Controllers/Payment/PaypalNotificationController.php
@@ -96,9 +96,8 @@ class PaypalNotificationController {
 	}
 
 	private function getDonationId( ParameterBag $postRequest ): int {
-		$itemId = $postRequest->getInt( 'item_number', 0 );
-		if ( $itemId ) {
-			return $itemId;
+		if ( $postRequest->has( 'item_number' ) && $postRequest->getInt( 'item_number' ) !== 0 ) {
+			return $postRequest->getInt( 'item_number' );
 		}
 
 		return (int)$this->getValueFromCustomVars( $postRequest->get( 'custom', '' ), 'sid' );


### PR DESCRIPTION
PayPal notifications without the `item_id` could trigger the error
`Input value "item_number" is invalid and flag "FILTER_NULL_ON_FAILURE" was not set`

This change checks for the parameter instead relying on defaults.
