### PR TITLE
Rename files to be both neutral and descriptive

### DIFF
--- a/.docker/app/config.dev.json
+++ b/.docker/app/config.dev.json
@@ -25,12 +25,12 @@
   },
   "text-policies": {
     "fields": {
-      "whitewords": "vendor/wmde/fundraising-frontend-content/data/white_words.txt",
-      "badwords": "vendor/wmde/fundraising-frontend-content/data/bad_words.txt"
+      "allowed-terms": "vendor/wmde/fundraising-frontend-content/data/allowed_terms.txt",
+      "banned-terms": "vendor/wmde/fundraising-frontend-content/data/banned_terms.txt"
     },
     "comment": {
-      "whitewords": "vendor/wmde/fundraising-frontend-content/data/white_words.txt",
-      "badwords": "vendor/wmde/fundraising-frontend-content/data/bad_words.txt"
+      "allowed-terms": "vendor/wmde/fundraising-frontend-content/data/allowed_terms.txt",
+      "banned-terms": "vendor/wmde/fundraising-frontend-content/data/banned_terms.txt"
     }
   },
   "i18n-base-path": "vendor/wmde/fundraising-frontend-content/i18n",

--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -45,12 +45,12 @@
 	},
 	"text-policies": {
 		"fields": {
-			"whitewords": "",
-			"badwords": ""
+			"allowed-terms": "",
+			"banned-terms": ""
 		},
 		"comment": {
-			"whitewords": "",
-			"badwords": ""
+			"allowed-terms": "",
+			"banned-terms": ""
 		}
 	},
 	"email-address-blacklist": [],

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -298,11 +298,11 @@
               "title": "Path to allowed words list",
               "default": ""
             },
-            "allowed_words": {
+            "allowed-terms": {
               "type": "string",
               "minLength": 0,
               "title": "Path to allowed words list",
-              "description": "Allowed words allow the words that were previously denied in the denied_words list",
+              "description": "Allowed words allow the words that were previously denied in the banned_terms list",
               "default": ""
             },
             "badwords": {
@@ -312,11 +312,11 @@
               "title": "Badwords Page Name",
               "default": ""
             },
-            "denied_words": {
+            "banned-terms": {
               "type": "string",
               "minLength": 0,
               "title": "Path to denied words list",
-              "description": "Denied words can be overridden by the allowed_words list",
+              "description": "Denied words can be overridden by the allowed_terms list",
               "default": ""
             }
           },
@@ -334,11 +334,11 @@
               "title": "Path to allowed words list",
               "default": ""
             },
-            "allowed_words": {
+            "allowed-terms": {
               "type": "string",
               "minLength": 0,
               "title": "Path to allowed words list",
-              "description": "Allowed words allow the words that were previously denied in the denied_words list",
+              "description": "Allowed words allow the words that were previously denied in the banned_terms list",
               "default": ""
             },
             "badwords": {
@@ -348,11 +348,11 @@
               "title": "Badwords Page Name",
               "default": ""
             },
-            "denied_words": {
+            "banned-terms": {
               "type": "string",
               "minLength": 0,
               "title": "Path to denied words list",
-              "description": "Denied words can be overridden by the allowed_words list",
+              "description": "Denied words can be overridden by the allowed_terms list",
               "default": ""
             }
           },

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -873,11 +873,11 @@ class FunFunFactory implements LoggerAwareInterface {
 		return new TextPolicyValidator(
 			new WordListFileReader(
 				$fetcher,
-				$this->getTextPolicyPathWithFallback( $policyName, 'denied_words', 'badwords' )
+				$this->getTextPolicyPathWithFallback( $policyName, 'banned-terms', 'badwords' )
 			),
 			new WordListFileReader(
 				$fetcher,
-				$this->getTextPolicyPathWithFallback( $policyName, 'allowed_words', 'whitewords' )
+				$this->getTextPolicyPathWithFallback( $policyName, 'allowed-terms', 'whitewords' )
 			)
 		);
 	}


### PR DESCRIPTION
- https://github.com/wmde/fundraising-frontend-content/pull/272
- https://github.com/wmde/fundraising-frontend-content/commit/3ebf4d976c5ca505970d25d484d57f89068ce629
- New file names: `allowed_terms.txt`, `banned_terms.txt`

Ticket: https://phabricator.wikimedia.org/T379726