### PR TITLE
Prepare campaign config for C24_WMDE_Mobile_DE_10

### DIFF
--- a/app/config/campaigns.dev.yml
+++ b/app/config/campaigns.dev.yml
@@ -1,11 +1,10 @@
 # This file is used in the "dev" and "uat" environments to be able to test future and past campaigns
 campaigns:
 
-  address_type_steps:
+  address_type_choice:
     active: true
-    start: "2022-11-01"
-    end: "2023-12-31"
-    default_bucket: "direct"
+    start: "2024-11-21"
+    end: "2024-12-31"
 
   membership_intervals:
     start: "2023-01-05"

--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -23,17 +23,16 @@ campaigns:
     # param_only: (Optional) Set to true if the campaign should return the default bucket when the url key is not in a request. This is for A/B tests triggered by banners
 
 
-    address_type_steps:
-      description: Test different kinds of address options, ask user whether they want receipt or just confirmation
-      reference: "https://phabricator.wikimedia.org/T342206"
-      start: "2023-08-08" # Banners start at 2023-08-10, earlier date is for testing the banners
-      end: "2023-12-31"
+    address_type_choice:
+      description: Test offering an "anonymous" choice (coming from a banner where the user donated less than 10 EUR)
+      reference: "https://phabricator.wikimedia.org/T380462"
+      start: "2024-11-25" 
+      end: "2024-12-31"
       buckets:
-        - "direct"
-        - "preselect"
-        - "full_or_email"
-      default_bucket: "direct"
-      url_key: ast
+        - "default"
+        - "choice"
+      default_bucket: "default"
+      url_key: xf
       active: true
       param_only: true
 


### PR DESCRIPTION
Remove the old configuration for address type choice (the relevant code
has not been in the fundraising app frontend for quite a while) and
replace it with a new configuration for the new campaign that tests
similar things, but with different implementations.

Ticket: https://phabricator.wikimedia.org/T380462
