### PR TITLE
Output campaign and keyword to front end

### DIFF
--- a/app/Controllers/Membership/ApplyForMembershipController.php
+++ b/app/Controllers/Membership/ApplyForMembershipController.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
-use WMDE\Fundraising\MembershipContext\Tracking\MembershipApplicationTrackingInfo;
+use WMDE\Fundraising\MembershipContext\Tracking\MembershipTracking;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplicationValidationResult;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplyForMembershipRequest;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplyForMembershipResponse;
@@ -50,7 +50,7 @@ class ApplyForMembershipController {
 	}
 
 	private function createMembershipRequest( Request $httpRequest ): ApplyForMembershipRequest {
-		$trackingInfo = new MembershipApplicationTrackingInfo(
+		$membershipTracking = new MembershipTracking(
 			$httpRequest->get( 'piwik_campaign', '' ),
 			$httpRequest->get( 'piwik_kwd', '' )
 		);
@@ -67,7 +67,7 @@ class ApplyForMembershipController {
 				optsIntoDonationReceipt: $httpRequest->request->getBoolean( 'donationReceipt', true ),
 				incentives: array_filter( $httpRequest->request->all( 'incentives' ) ),
 				paymentParameters: $this->newPaymentParameters( $httpRequest ),
-				trackingInfo: $trackingInfo,
+				trackingInfo: $membershipTracking,
 			);
 		} else {
 			return ApplyForMembershipRequest::newPrivateApplyForMembershipRequest(
@@ -84,7 +84,7 @@ class ApplyForMembershipController {
 				optsIntoDonationReceipt: $httpRequest->request->getBoolean( 'donationReceipt', true ),
 				incentives: array_filter( $httpRequest->request->all( 'incentives' ) ),
 				paymentParameters: $this->newPaymentParameters( $httpRequest ),
-				trackingInfo: $trackingInfo,
+				trackingInfo: $membershipTracking,
 				applicantDateOfBirth: $httpRequest->request->get( 'dob', '' ),
 			);
 		}

--- a/app/Controllers/Membership/ApplyForMembershipController.php
+++ b/app/Controllers/Membership/ApplyForMembershipController.php
@@ -51,8 +51,8 @@ class ApplyForMembershipController {
 
 	private function createMembershipRequest( Request $httpRequest ): ApplyForMembershipRequest {
 		$trackingInfo = new MembershipApplicationTrackingInfo(
-			$httpRequest->request->get( 'templateCampaign', '' ),
-			$httpRequest->request->get( 'templateName', '' )
+			$httpRequest->get( 'piwik_campaign', '' ),
+			$httpRequest->get( 'piwik_kwd', '' )
 		);
 
 		if ( $httpRequest->request->get( 'adresstyp', '' ) === 'firma' ) {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"wmde/euro": "~1.0",
 		"wmde/clock": "~1.0",
 		"wmde/fundraising-donations": "~21.0",
-		"wmde/fundraising-memberships": "~16.2",
+		"wmde/fundraising-memberships": "dev-ouput-stored-tracking",
 		"wmde/fundraising-payments": "~8.0",
 		"wmde/fundraising-subscriptions": "~5.0",
 		"wmde/fundraising-content-provider": "~6.1",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"wmde/euro": "~1.0",
 		"wmde/clock": "~1.0",
 		"wmde/fundraising-donations": "~21.0",
-		"wmde/fundraising-memberships": "dev-ouput-stored-tracking",
+		"wmde/fundraising-memberships": "~17.0",
 		"wmde/fundraising-payments": "~8.0",
 		"wmde/fundraising-subscriptions": "~5.0",
 		"wmde/fundraising-content-provider": "~6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d566ff1c0d65d7b06ec900de17ad663",
+    "content-hash": "a4894c02ae4bccbf1f77b0cafa3ddbfe",
     "packages": [
         {
             "name": "airbrake/phpbrake",
@@ -6996,16 +6996,16 @@
         },
         {
             "name": "wmde/fundraising-memberships",
-            "version": "v16.2.0",
+            "version": "dev-ouput-stored-tracking",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-memberships",
-                "reference": "d3e37db02c3518d1b371745ecfdff60f5ca2039f"
+                "reference": "1f7ac3a44db8412df2a8ed4e54d651a0c2adc96f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-memberships/zipball/d3e37db02c3518d1b371745ecfdff60f5ca2039f",
-                "reference": "d3e37db02c3518d1b371745ecfdff60f5ca2039f",
+                "url": "https://api.github.com/repos/wmde/fundraising-memberships/zipball/1f7ac3a44db8412df2a8ed4e54d651a0c2adc96f",
+                "reference": "1f7ac3a44db8412df2a8ed4e54d651a0c2adc96f",
                 "shasum": ""
             },
             "require": {
@@ -7052,7 +7052,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Bounded Context for the Wikimedia Deutschland fundraising membership subdomain",
-            "time": "2024-09-04T09:34:55+00:00"
+            "time": "2024-12-20T07:57:41+00:00"
         },
         {
             "name": "wmde/fundraising-payments",
@@ -10341,6 +10341,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "wmde/fundraising-memberships": 20,
         "airbrake/phpbrake": 20,
         "remotelyliving/doorkeeper": 20,
         "wmde/fundraising-frontend-content": 20
@@ -10360,5 +10361,5 @@
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a4894c02ae4bccbf1f77b0cafa3ddbfe",
+    "content-hash": "e7dca8712a83a3fad846309fed522a31",
     "packages": [
         {
             "name": "airbrake/phpbrake",
@@ -6996,16 +6996,16 @@
         },
         {
             "name": "wmde/fundraising-memberships",
-            "version": "dev-ouput-stored-tracking",
+            "version": "v17.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-memberships",
-                "reference": "1f7ac3a44db8412df2a8ed4e54d651a0c2adc96f"
+                "reference": "da31cb81882045eb470ad6c767289a41d40e1312"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-memberships/zipball/1f7ac3a44db8412df2a8ed4e54d651a0c2adc96f",
-                "reference": "1f7ac3a44db8412df2a8ed4e54d651a0c2adc96f",
+                "url": "https://api.github.com/repos/wmde/fundraising-memberships/zipball/da31cb81882045eb470ad6c767289a41d40e1312",
+                "reference": "da31cb81882045eb470ad6c767289a41d40e1312",
                 "shasum": ""
             },
             "require": {
@@ -7052,7 +7052,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Bounded Context for the Wikimedia Deutschland fundraising membership subdomain",
-            "time": "2024-12-20T07:57:41+00:00"
+            "time": "2024-12-27T13:56:51+00:00"
         },
         {
             "name": "wmde/fundraising-payments",
@@ -10191,12 +10191,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-frontend-content",
-                "reference": "3ffdd41d8216387e04dbda2d73b91da32fdfb441"
+                "reference": "c3fa5992ee4d47d79d6636b1d0b33fc736b63b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/3ffdd41d8216387e04dbda2d73b91da32fdfb441",
-                "reference": "3ffdd41d8216387e04dbda2d73b91da32fdfb441",
+                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/c3fa5992ee4d47d79d6636b1d0b33fc736b63b5b",
+                "reference": "c3fa5992ee4d47d79d6636b1d0b33fc736b63b5b",
                 "shasum": ""
             },
             "require": {
@@ -10247,7 +10247,7 @@
                 "CC0-1.0"
             ],
             "description": "i18n for FundraisingFrontend",
-            "time": "2024-12-17T10:33:26+00:00"
+            "time": "2024-12-23T15:10:22+00:00"
         },
         {
             "name": "wmde/fundraising-phpcs",
@@ -10341,7 +10341,6 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "wmde/fundraising-memberships": 20,
         "airbrake/phpbrake": 20,
         "remotelyliving/doorkeeper": 20,
         "wmde/fundraising-frontend-content": 20
@@ -10361,5 +10360,5 @@
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -190,18 +190,16 @@ use WMDE\Fundraising\Frontend\Validation\GetInTouchValidator;
 use WMDE\Fundraising\Frontend\Validation\IsCustomAmountValidator;
 use WMDE\Fundraising\MembershipContext\Authorization\MembershipAuthorizationChecker;
 use WMDE\Fundraising\MembershipContext\Authorization\MembershipAuthorizer;
-use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineApplicationPiwikTracker;
-use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineApplicationTracker;
 use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineIncentiveFinder;
 use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineMembershipIdGenerator;
 use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineMembershipRepository;
+use WMDE\Fundraising\MembershipContext\DataAccess\DoctrineMembershipTrackingRepository;
 use WMDE\Fundraising\MembershipContext\DataAccess\IncentiveFinder;
 use WMDE\Fundraising\MembershipContext\DataAccess\ModerationReasonRepository as MembershipModerationReasonRepository;
 use WMDE\Fundraising\MembershipContext\Domain\Repositories\MembershipRepository;
 use WMDE\Fundraising\MembershipContext\Infrastructure\PaymentServiceFactory;
 use WMDE\Fundraising\MembershipContext\MembershipContextFactory;
-use WMDE\Fundraising\MembershipContext\Tracking\ApplicationPiwikTracker;
-use WMDE\Fundraising\MembershipContext\Tracking\ApplicationTracker;
+use WMDE\Fundraising\MembershipContext\Tracking\MembershipTrackingRepository;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\ApplyForMembershipUseCase;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\MembershipApplicationValidator;
 use WMDE\Fundraising\MembershipContext\UseCases\ApplyForMembership\Moderation\ModerationService as MembershipModerationService;
@@ -1240,8 +1238,7 @@ class FunFunFactory implements LoggerAwareInterface {
 			),
 			$this->newMembershipApplicationValidator(),
 			$this->newApplyForMembershipPolicyValidator(),
-			$this->newMembershipApplicationTracker(),
-			$this->newMembershipApplicationPiwikTracker(),
+			$this->newMembershipTrackingRepository(),
 			$this->getMembershipEventEmitter(),
 			$this->getIncentiveFinder(),
 			$this->newPaymentServiceFactory()
@@ -1300,12 +1297,8 @@ class FunFunFactory implements LoggerAwareInterface {
 		);
 	}
 
-	private function newMembershipApplicationTracker(): ApplicationTracker {
-		return new DoctrineApplicationTracker( $this->getEntityManager() );
-	}
-
-	private function newMembershipApplicationPiwikTracker(): ApplicationPiwikTracker {
-		return new DoctrineApplicationPiwikTracker( $this->getEntityManager() );
+	private function newMembershipTrackingRepository(): MembershipTrackingRepository {
+		return new DoctrineMembershipTrackingRepository( $this->getEntityManager() );
 	}
 
 	public function setPaymentDelayCalculator( PaymentDelayCalculator $paymentDelayCalculator ): void {
@@ -1352,7 +1345,7 @@ class FunFunFactory implements LoggerAwareInterface {
 			$this->getMembershipApplicationAuthorizer( '', $accessToken ),
 			$this->getMembershipApplicationRepository(),
 			$this->newGetPaymentUseCase(),
-			$this->newMembershipApplicationPiwikTracker()
+			$this->newMembershipTrackingRepository()
 		);
 	}
 

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1351,7 +1351,8 @@ class FunFunFactory implements LoggerAwareInterface {
 			$presenter,
 			$this->getMembershipApplicationAuthorizer( '', $accessToken ),
 			$this->getMembershipApplicationRepository(),
-			$this->newGetPaymentUseCase()
+			$this->newGetPaymentUseCase(),
+			$this->newMembershipApplicationPiwikTracker()
 		);
 	}
 

--- a/src/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenter.php
@@ -24,12 +24,14 @@ class MembershipApplicationConfirmationHtmlPresenter implements ShowApplicationC
 	/**
 	 * @param MembershipApplication $application
 	 * @param array<string, scalar> $paymentData
+	 * @param string $tracking
 	 */
-	public function presentConfirmation( MembershipApplication $application, array $paymentData ): void {
+	public function presentConfirmation( MembershipApplication $application, array $paymentData, string $tracking ): void {
 		$this->html = $this->template->render(
 			$this->getConfirmationPageArguments(
 				$application,
 				$paymentData,
+				$tracking
 			)
 		);
 	}
@@ -49,10 +51,11 @@ class MembershipApplicationConfirmationHtmlPresenter implements ShowApplicationC
 	/**
 	 * @param MembershipApplication $membershipApplication
 	 * @param array<string, scalar> $paymentData
+	 * @param string $tracking
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function getConfirmationPageArguments( MembershipApplication $membershipApplication, array $paymentData ): array {
+	private function getConfirmationPageArguments( MembershipApplication $membershipApplication, array $paymentData, string $tracking ): array {
 		return [
 			'membershipApplication' => $this->getApplicationArguments( $membershipApplication, $paymentData ),
 			'address' => $this->getAddressArguments( $membershipApplication->getApplicant() ),
@@ -60,7 +63,8 @@ class MembershipApplicationConfirmationHtmlPresenter implements ShowApplicationC
 				'iban' => $paymentData['iban'] ?? '',
 				'bic' => $paymentData['bic'] ?? '',
 				'bankname' => $paymentData['bankname'] ?? '',
-			]
+			],
+			'tracking' => $tracking
 		];
 	}
 

--- a/src/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenter.php
@@ -10,6 +10,7 @@ use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
 use WMDE\Fundraising\MembershipContext\Domain\Model\Applicant;
 use WMDE\Fundraising\MembershipContext\Domain\Model\ApplicantName;
 use WMDE\Fundraising\MembershipContext\Domain\Model\MembershipApplication;
+use WMDE\Fundraising\MembershipContext\Tracking\MembershipTracking;
 use WMDE\Fundraising\MembershipContext\UseCases\ShowApplicationConfirmation\ShowApplicationConfirmationPresenter;
 
 class MembershipApplicationConfirmationHtmlPresenter implements ShowApplicationConfirmationPresenter {
@@ -24,9 +25,9 @@ class MembershipApplicationConfirmationHtmlPresenter implements ShowApplicationC
 	/**
 	 * @param MembershipApplication $application
 	 * @param array<string, scalar> $paymentData
-	 * @param string $tracking
+	 * @param MembershipTracking $tracking
 	 */
-	public function presentConfirmation( MembershipApplication $application, array $paymentData, string $tracking ): void {
+	public function presentConfirmation( MembershipApplication $application, array $paymentData, MembershipTracking $tracking ): void {
 		$this->html = $this->template->render(
 			$this->getConfirmationPageArguments(
 				$application,
@@ -51,11 +52,11 @@ class MembershipApplicationConfirmationHtmlPresenter implements ShowApplicationC
 	/**
 	 * @param MembershipApplication $membershipApplication
 	 * @param array<string, scalar> $paymentData
-	 * @param string $tracking
+	 * @param MembershipTracking $tracking
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function getConfirmationPageArguments( MembershipApplication $membershipApplication, array $paymentData, string $tracking ): array {
+	private function getConfirmationPageArguments( MembershipApplication $membershipApplication, array $paymentData, MembershipTracking $tracking ): array {
 		return [
 			'membershipApplication' => $this->getApplicationArguments( $membershipApplication, $paymentData ),
 			'address' => $this->getAddressArguments( $membershipApplication->getApplicant() ),
@@ -64,7 +65,7 @@ class MembershipApplicationConfirmationHtmlPresenter implements ShowApplicationC
 				'bic' => $paymentData['bic'] ?? '',
 				'bankname' => $paymentData['bankname'] ?? '',
 			],
-			'tracking' => $tracking
+			'tracking' => $tracking->__toString()
 		];
 	}
 

--- a/tests/EdgeToEdge/WebRouteTestCase.php
+++ b/tests/EdgeToEdge/WebRouteTestCase.php
@@ -235,7 +235,8 @@ abstract class WebRouteTestCase extends KernelTestCase {
 		$initialFormValues = $client->getCrawler()->filter( 'script[data-initial-form-values]' );
 		$this->assertGreaterThan(
 			0,
-			$initialFormValues->count()
+			$initialFormValues->count(),
+			'HTML should contain initial values'
 		);
 		$json = $initialFormValues->attr( 'data-initial-form-values' ) ?? '';
 		$data = json_decode( $json, true );

--- a/tests/Integration/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenterTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use WMDE\Fundraising\Frontend\Presentation\Presenters\MembershipApplicationConfirmationHtmlPresenter;
 use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
 use WMDE\Fundraising\MembershipContext\Tests\Fixtures\ValidMembershipApplication;
+use WMDE\Fundraising\MembershipContext\Tracking\MembershipTracking;
 
 #[CoversClass( MembershipApplicationConfirmationHtmlPresenter::class )]
 class MembershipApplicationConfirmationHtmlPresenterTest extends TestCase {
@@ -32,7 +33,7 @@ class MembershipApplicationConfirmationHtmlPresenterTest extends TestCase {
 				'bic' => 'I has BIC',
 				'bankname' => 'I has BANK',
 			],
-			'I has CAMPAIGN/I has KEYWORD'
+			new MembershipTracking( 'I has CAMPAIGN', 'I has KEYWORD' )
 		);
 	}
 

--- a/tests/Integration/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenterTest.php
@@ -32,6 +32,7 @@ class MembershipApplicationConfirmationHtmlPresenterTest extends TestCase {
 				'bic' => 'I has BIC',
 				'bankname' => 'I has BANK',
 			],
+			'I has CAMPAIGN/I has KEYWORD'
 		);
 	}
 
@@ -66,7 +67,8 @@ class MembershipApplicationConfirmationHtmlPresenterTest extends TestCase {
 				'iban' => 'I has IBAN',
 				'bic' => 'I has BIC',
 				'bankname' => 'I has BANK',
-			]
+			],
+			'tracking' => 'I has CAMPAIGN/I has KEYWORD'
 		];
 	}
 


### PR DESCRIPTION
- Fix the storage of the campaign and keyword in ApplyForMembershipController
- Output the stored banner campaign and keyword to make them available to the front end
- Add route test to ensure this round trip returns the required data fields

Ticket: https://phabricator.wikimedia.org/T381958