### PR TITLE
Improve PayPal notifications

### DIFF
--- a/app/Controllers/Payment/PaypalNotificationController.php
+++ b/app/Controllers/Payment/PaypalNotificationController.php
@@ -96,8 +96,9 @@ class PaypalNotificationController {
 	}
 
 	private function getDonationId( ParameterBag $postRequest ): int {
-		if ( $postRequest->has( 'item_number' ) && $postRequest->getInt( 'item_number' ) !== 0 ) {
-			return $postRequest->getInt( 'item_number' );
+		$itemNumber = $postRequest->filter( 'item_number', 0, FILTER_VALIDATE_INT, [ 'options' => [ 'default' => 0 ] ] );
+		if ( $itemNumber !== 0 ) {
+			return $itemNumber;
 		}
 
 		return (int)$this->getValueFromCustomVars( $postRequest->get( 'custom', '' ), 'sid' );

--- a/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
@@ -71,6 +71,26 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 		$this->assertPayPalDataGotPersisted( $this->newHttpParamsForPayment() );
 	}
 
+	public function testGivenRequestWithEmptyItemId_getsIdFromCustomArray(): void {
+		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$factory->setVerificationServiceFactory( new SucceedingVerificationServiceFactory() );
+
+		$this->storedDonations()->newStoredIncompletePayPalDonation( self::UPDATE_TOKEN );
+
+		$request = $this->newHttpParamsForPayment();
+		$request['item_number'] = '';
+
+		$client->request(
+			Request::METHOD_POST,
+			self::PATH,
+			$request
+		);
+
+		$this->assertSame( 200, $client->getResponse()->getStatusCode() );
+		$this->assertPayPalDataGotPersisted( $this->newHttpParamsForPayment() );
+	}
+
 	public function testGivenValidRequestToLegacyPath_applicationIndicatesSuccess(): void {
 		$client = $this->createClient();
 		$factory = $this->getFactory();


### PR DESCRIPTION
We have a notification where the `item_number` (that can contain the
donation ID) is present, but an empty string. We can't use
`ParameterBag::getInt` in this case, because it strictly validates the
number and an empty string will cause the validation to fail.
Instead, we now use `ParameterBag::filter`, which handles both
cases (empty and invalid).

See https://www.php.net/manual/en/function.filter-var.php for more
information (`ParameterBag::filter` is a wrapper around `filter_var`
with additional checks).
