### PR TITLE
Extend the address_pages AB test end date

### DIFF
--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -26,7 +26,7 @@ campaigns:
     address_type_choice:
       description: Test offering an "anonymous" choice (coming from a banner where the user donated less than 10 EUR)
       reference: "https://phabricator.wikimedia.org/T380462"
-      start: "2024-11-25" 
+      start: "2024-11-25"
       end: "2024-12-31"
       buckets:
         - "default"
@@ -53,7 +53,7 @@ campaigns:
       description: Test different iterations of address pages
       reference: "https://phabricator.wikimedia.org/T366576"
       start: "2024-07-01"
-      end: "2024-12-31"
+      end: "2026-02-28"
       buckets:
         - "legacy"
         - "test_02"


### PR DESCRIPTION
- the `test_02` bucket (ap=1) is still used in the last banners from 2024, so we still want to be able to navigate to the different buckets with an URL parameter. For that the end date had to be adjusted.

https://phabricator.wikimedia.org/T385562