### PR TITLE
Remove deprecated route definition

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -68,16 +68,6 @@ generate_iban:
     methods: [GET]
     controller: 'WMDE\Fundraising\Frontend\App\Controllers\Payment\BankDataToIbanController::index'
 
-PostComment:
-    path: /add-comment
-    methods: [POST]
-    controller: 'WMDE\Fundraising\Frontend\App\Controllers\Donation\AddCommentController::index'
-
-AddCommentPage:
-    path: /add-comment
-    methods: [GET]
-    controller: 'WMDE\Fundraising\Frontend\App\Controllers\Donation\AddCommentController::index'
-
 POST_contact_get_in_touch:
     path: /contact/get-in-touch
     methods: [POST]

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1207,7 +1207,6 @@ class FunFunFactory implements LoggerAwareInterface {
 					]
 				)
 			),
-			$this->getUrlGenerator(),
 			$this->getUrlAuthenticationLoader(),
 			$this->getCountries(),
 			$this->getValidationRules()->address,

--- a/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
@@ -8,7 +8,6 @@ use WMDE\Euro\Euro;
 use WMDE\Fundraising\DonationContext\Domain\Model\Donation;
 use WMDE\Fundraising\Frontend\Authentication\DonationUrlAuthenticationLoader;
 use WMDE\Fundraising\Frontend\Infrastructure\AddressType;
-use WMDE\Fundraising\Frontend\Infrastructure\UrlGenerator;
 use WMDE\Fundraising\Frontend\Presentation\DonorDataFormatter;
 use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
 
@@ -21,14 +20,12 @@ class DonationConfirmationHtmlPresenter {
 
 	/**
 	 * @param TwigTemplate $template
-	 * @param UrlGenerator $urlGenerator
 	 * @param DonationUrlAuthenticationLoader $authenticationLoader
 	 * @param array<string, mixed> $countries
 	 * @param \stdClass $validation
 	 */
 	public function __construct(
 		private readonly TwigTemplate $template,
-		private readonly UrlGenerator $urlGenerator,
 		private readonly DonationUrlAuthenticationLoader $authenticationLoader,
 		private readonly array $countries,
 		\stdClass $validation
@@ -89,20 +86,7 @@ class DonationConfirmationHtmlPresenter {
 			],
 			'urls' => [
 				...$urlEndpoints,
-				'addComment'  => $this->createUrlForAddingComment( $donation->getId() ),
 			]
 		];
-	}
-
-	private function createUrlForAddingComment( int $donationId ): string {
-		return $this->urlGenerator->generateRelativeUrl(
-			'AddCommentPage',
-			$this->authenticationLoader->addDonationAuthorizationParameters(
-				$donationId,
-				[
-					'donationId' => $donationId,
-				]
-			)
-		);
 	}
 }

--- a/tests/Integration/Presentation/Presenters/DonationConfirmationHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/DonationConfirmationHtmlPresenterTest.php
@@ -11,7 +11,6 @@ use WMDE\Fundraising\DonationContext\Tests\Data\ValidDonation;
 use WMDE\Fundraising\Frontend\Presentation\Presenters\DonationConfirmationHtmlPresenter;
 use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\DonationUrlAuthenticationLoaderStub;
-use WMDE\Fundraising\Frontend\Tests\Fixtures\FakeUrlGenerator;
 
 #[CoversClass( DonationConfirmationHtmlPresenter::class )]
 class DonationConfirmationHtmlPresenterTest extends TestCase {
@@ -25,7 +24,6 @@ class DonationConfirmationHtmlPresenterTest extends TestCase {
 
 		$presenter = new DonationConfirmationHtmlPresenter(
 			$this->newTwigTemplateMock( $expectedParameters ),
-			new FakeUrlGenerator(),
 			new DonationUrlAuthenticationLoaderStub( [
 				'updateToken' => self::UPDATE_TOKEN,
 				'accessToken' => self::ACCESS_TOKEN,
@@ -83,7 +81,6 @@ class DonationConfirmationHtmlPresenterTest extends TestCase {
 			],
 			'urls' => [
 				'testUrl' => 'https://example.com/',
-				'addComment' => '/such.a.url/AddCommentPage?donationId=42&updateToken=update_token&accessToken=access_token'
 			],
 			'countries' => [],
 			'addressValidationPatterns' => (object)[],


### PR DESCRIPTION
We replaced the comment page with an API for [T367387](https://phabricator.wikimedia.org/T367387),
removed the controller, but forgot to remove the route definition that
lead to the controller.
