### PR TITLE
Rename project in composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-	"name": "wmde/fundraising-frontend",
+	"name": "wmde/fundraising-application",
 	"description": "WMDE fundraising application (end user facing part)",
-	"homepage": "https://github.com/wmde/FundraisingFrontend",
+	"homepage": "https://github.com/wmde/fundraising-application",
 	"license": "GPL-2.0+",
 	"require": {
 		"php": ">=8.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c341a5344b92a656847edac854071ecb",
+    "content-hash": "a27906a412738189dda3b0c12ec5ef8f",
     "packages": [
         {
             "name": "airbrake/phpbrake",
@@ -8841,16 +8841,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.1.2",
+            "version": "12.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6f2775cc4b7b19ba5a411c188e855eb0cc78a711"
+                "reference": "72ca50e817dd7d65356c16772c30f06c01a6fae2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6f2775cc4b7b19ba5a411c188e855eb0cc78a711",
-                "reference": "6f2775cc4b7b19ba5a411c188e855eb0cc78a711",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/72ca50e817dd7d65356c16772c30f06c01a6fae2",
+                "reference": "72ca50e817dd7d65356c16772c30f06c01a6fae2",
                 "shasum": ""
             },
             "require": {
@@ -8918,7 +8918,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.1.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.1.3"
             },
             "funding": [
                 {
@@ -8930,11 +8930,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-08T08:05:27+00:00"
+            "time": "2025-04-22T06:11:09+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -10217,12 +10225,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-frontend-content",
-                "reference": "18bff4233a15a49cb323f55bdaaeaec1b4b83c6a"
+                "reference": "deeffa2ba283c3fcd26dd27870a65d8c171208d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/18bff4233a15a49cb323f55bdaaeaec1b4b83c6a",
-                "reference": "18bff4233a15a49cb323f55bdaaeaec1b4b83c6a",
+                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/deeffa2ba283c3fcd26dd27870a65d8c171208d2",
+                "reference": "deeffa2ba283c3fcd26dd27870a65d8c171208d2",
                 "shasum": ""
             },
             "require": {
@@ -10273,7 +10281,7 @@
                 "CC0-1.0"
             ],
             "description": "i18n for FundraisingFrontend",
-            "time": "2025-04-10T12:42:14+00:00"
+            "time": "2025-04-22T09:47:27+00:00"
         },
         {
             "name": "wmde/fundraising-phpcs",
@@ -10386,5 +10394,5 @@
     "platform-overrides": {
         "php": "8.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
When we split frontend and backend code of the Fundraising Application,
we also tried to made sure to call it "Fundraising Application" instead
of "Fundraising Frontend" (as opposed to "Backend", which is the
Fundraising Operation Center). This commit fixes that legacy naming in
the composer files.
