### PR TITLE
Remove Matomo fallback tracking

### DIFF
--- a/skins/laika/templates/matomo.html.twig
+++ b/skins/laika/templates/matomo.html.twig
@@ -24,5 +24,4 @@
 		s.parentNode.insertBefore( g, s );
 	} ) ();
 </script>
-<noscript><img src="{$ piwik.baseUrl $}piwik.php?idsite={$ piwik.siteId $}" style="border:0;width:1px" alt=""></noscript>
 <!-- End Matomo Code -->


### PR DESCRIPTION
Remove link to "tracking image" that gets loaded when user has disabled
JavaScript.

This change is a shot in the dark to try and make an PCI ASV test pass. If the
test still fails (because we load the tracker with JavaScript), revert
this change.

This change is an "emergency fix" to meet a deadline as fast as
possible. It's not coordinated with the campaigns team and should be
reverted if they object to it.
