### PR TITLE
Improve output of JSON validation errors

### DIFF
--- a/tests/EdgeToEdge/APIParameterValidationTest.php
+++ b/tests/EdgeToEdge/APIParameterValidationTest.php
@@ -1,0 +1,42 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\EdgeToEdge;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use WMDE\Fundraising\Frontend\App\EventHandlers\HandleExceptions;
+
+#[CoversClass( HandleExceptions::class )]
+class APIParameterValidationTest extends WebRouteTestCase {
+	/**
+	 * We're using this API route as an example because it uses the #[MapRequestPayload] attribute
+	 */
+	private const string PATH = '/api/v1/donation/comment';
+
+	public function testGivenJSONRequestWithoutParameters_responseContainsFieldNames(): void {
+		/** @var KernelBrowser $client */
+		$client = $this->createClient();
+
+		$client->jsonRequest(
+			Request::METHOD_POST,
+			self::PATH,
+			[]
+		);
+
+		$response = $client->getResponse();
+		$responseJson = json_decode( $response->getContent() ?: '', true, 512, JSON_THROW_ON_ERROR );
+		$this->assertSame( Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode() );
+		$this->assertIsArray( $responseJson );
+		$this->assertArrayHasKey( 'validationErrors', $responseJson );
+		$this->assertSame(
+			[
+				'comment' => 'This value should be of type string.',
+				'donationId' => 'This value should be of type int.',
+			],
+			$responseJson['validationErrors']
+		);
+	}
+}

--- a/tests/EdgeToEdge/APIRoutes/AddCommentPostRouteTest.php
+++ b/tests/EdgeToEdge/APIRoutes/AddCommentPostRouteTest.php
@@ -33,7 +33,11 @@ class AddCommentPostRouteTest extends WebRouteTestCase {
 		);
 
 		$response = $client->getResponse();
+		$responseJson = json_decode( $response->getContent() ?: '', true, 512, JSON_THROW_ON_ERROR );
 		$this->assertSame( Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode() );
+		$this->assertIsArray( $responseJson );
+		// validationErrors is an indicator that Symfony could not validate the JSON body and turn it into a request object
+		$this->assertArrayHasKey( 'validationErrors', $responseJson );
 	}
 
 	public function testGivenRequestWithoutTokens_resultIsError(): void {


### PR DESCRIPTION
When using the `#[MapRequestPayload]` attribute, Symfony will throw a `ValidationFailedException` if the JSON sent by the client does not match the expected class definition (e.g. missing field, fields of wrong type, etc). This commit adds an `validationErrors` field to the resulting JSON with `field name => error` pairs to help the developer debug the fields better.

We keep the `ERR` property in the result as an "indicator" value for backwards compatibility.