### PR TITLE
Use Credit Card Logger for CC IPNs

### DIFF
--- a/app/Controllers/Payment/CreditCardPaymentNotificationController.php
+++ b/app/Controllers/Payment/CreditCardPaymentNotificationController.php
@@ -55,7 +55,7 @@ class CreditCardPaymentNotificationController {
 			$response = $ffFactory->newBookDonationUseCase( $queryParams->get( 'utoken', '' ) )
 				->handleNotification( new NotificationRequest( $queryParams->all(), intval( $donationId ) ) );
 		} catch ( \Exception $e ) {
-			$ffFactory->getLogger()->critical(
+			$ffFactory->getCreditCardLogger()->critical(
 				sprintf( self::MSG_CRITICAL, $e->getMessage() ),
 				[ 'stacktrace' => $e->getTraceAsString() ]
 			);
@@ -63,7 +63,7 @@ class CreditCardPaymentNotificationController {
 		}
 
 		if ( $response->hasErrors() ) {
-			$ffFactory->getLogger()->error(
+			$ffFactory->getCreditCardLogger()->error(
 				sprintf( self::MSG_ERROR, $response->getMessage() ),
 				[ 'queryParams' => $queryParams->all(), 'clientIP' => $clientIp ]
 			);

--- a/tests/EdgeToEdge/Routes/CreditCardPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/CreditCardPaymentNotificationRouteTest.php
@@ -128,7 +128,7 @@ class CreditCardPaymentNotificationRouteTest extends WebRouteTestCase {
 	public function testGivenRequestForMissingDonation_applicationLogsRequest(): void {
 		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ): void {
 			$logger = new LoggerSpy();
-			$factory->setLogger( $logger );
+			$factory->setCreditCardLogger( $logger );
 			$requestData = $this->newDefaultRequestParametersFromMCP();
 
 			$client->request(
@@ -165,7 +165,7 @@ class CreditCardPaymentNotificationRouteTest extends WebRouteTestCase {
 	public function testOnInternalError_applicationLogsError(): void {
 		$this->createEnvironment( function ( Client $client, FunFunFactory $factory ): void {
 			$logger = new LoggerSpy();
-			$factory->setLogger( $logger );
+			$factory->setCreditCardLogger( $logger );
 
 			$repository = new ThrowingDonationRepository();
 			$repository->throwOnGetDonationById();


### PR DESCRIPTION
The application logger was incorrectly being used to
log errors in our credit card IPNs. This hooks it up
properly.

Ticket: https://phabricator.wikimedia.org/T434868