### PR TITLE
Postpone PayPal API usage to 2027

### DIFF
--- a/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
@@ -690,13 +690,13 @@ class AddDonationRouteTest extends WebRouteTestCase {
 	}
 
 	/**
-	 * We expect the transition to the PayPal API to be done in mid-2026
+	 * We expect the transition to the PayPal API to be done in mid-2027
 	 * Ticket: https://phabricator.wikimedia.org/T329159
 	 *
 	 * @todo remove when ticket is done
 	 */
 	public function canaryForRemovingLegacyPayPalURLGeneratorConfig(): void {
-		if ( time() > strtotime( '2026-08-30' ) ) {
+		if ( time() > strtotime( '2027-08-30' ) ) {
 			$this->fail( "----NOTE: These tests are failing because we've set an EOL date for them----" );
 		}
 	}


### PR DESCRIPTION
Adapt date in canary test that failed.
We did not manage to pick up the topic in 2026