### PR TITLE
Update Application for new Membership Release

### DIFF
--- a/cli/AnonymiseMemberCommand.php
+++ b/cli/AnonymiseMemberCommand.php
@@ -40,7 +40,9 @@ class AnonymiseMemberCommand extends Command {
 			new DatabasePaymentAnonymizer(
 				paymentRepository: $this->ffFactory->getPaymentRepository(),
 				entityManager: $this->ffFactory->getEntityManager()
-			)
+			),
+			new SystemClock(),
+			new \DateInterval( 'P2D' )
 		);
 
 		try {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"wmde/euro": "~1.0",
 		"wmde/clock": "~2.0",
 		"wmde/fundraising-donations": "~29.0",
-		"wmde/fundraising-memberships": "~20.2",
+		"wmde/fundraising-memberships": "~21.0",
 		"wmde/fundraising-payments": "~8.4",
 		"wmde/fundraising-subscriptions": "6.0",
 		"wmde/fundraising-content-provider": "~6.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "34fa717b477e33fa0d9d5cc203fc301c",
+    "content-hash": "ca19d1e5d4a134b7f7d77d0d150f5767",
     "packages": [
         {
             "name": "airbrake/phpbrake",
@@ -2041,16 +2041,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.3",
+            "version": "2.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
+                "reference": "148cefffaf0233e4c08cc13db8a195a56dd6dfe9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
-                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/148cefffaf0233e4c08cc13db8a195a56dd6dfe9",
+                "reference": "148cefffaf0233e4c08cc13db8a195a56dd6dfe9",
                 "shasum": ""
             },
             "require": {
@@ -2082,9 +2082,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.5"
             },
-            "time": "2026-07-08T07:01:06+00:00"
+            "time": "2026-08-31T16:05:28+00:00"
         },
         {
             "name": "psr/cache",
@@ -4067,16 +4067,16 @@
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.7.1",
+            "version": "v3.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "41fc42d276aeff21192465331ebbab7d83a743c0"
+                "reference": "35be0019e2c2c9fba80f9dc033290a5240f7b44f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/41fc42d276aeff21192465331ebbab7d83a743c0",
-                "reference": "41fc42d276aeff21192465331ebbab7d83a743c0",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/35be0019e2c2c9fba80f9dc033290a5240f7b44f",
+                "reference": "35be0019e2c2c9fba80f9dc033290a5240f7b44f",
                 "shasum": ""
             },
             "require": {
@@ -4125,7 +4125,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.1"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.3"
             },
             "funding": [
                 {
@@ -4145,7 +4145,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-05T06:23:12+00:00"
+            "time": "2026-08-04T08:41:16+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -4909,16 +4909,16 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.38.1",
+            "version": "v1.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
+                "reference": "51b5ff5ba85452b31ec6f55490b08148612339d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
-                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/51b5ff5ba85452b31ec6f55490b08148612339d9",
+                "reference": "51b5ff5ba85452b31ec6f55490b08148612339d9",
                 "shasum": ""
             },
             "require": {
@@ -4972,7 +4972,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.42.0"
             },
             "funding": [
                 {
@@ -4992,7 +4992,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T15:22:23+00:00"
+            "time": "2026-08-24T10:51:20+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
@@ -7219,16 +7219,16 @@
         },
         {
             "name": "wmde/fundraising-memberships",
-            "version": "v20.2.0",
+            "version": "v21.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-memberships",
-                "reference": "d418052bf30228ad1c93f9af75e8679e33e5f1b3"
+                "reference": "f8d6adebf72d8511c597f84c55d47fd72db26e55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-memberships/zipball/d418052bf30228ad1c93f9af75e8679e33e5f1b3",
-                "reference": "d418052bf30228ad1c93f9af75e8679e33e5f1b3",
+                "url": "https://api.github.com/repos/wmde/fundraising-memberships/zipball/f8d6adebf72d8511c597f84c55d47fd72db26e55",
+                "reference": "f8d6adebf72d8511c597f84c55d47fd72db26e55",
                 "shasum": ""
             },
             "require": {
@@ -7236,19 +7236,19 @@
                 "doctrine/orm": "~3.0",
                 "php": ">=8.4",
                 "psr/log": "~3.0",
+                "wmde/clock": "^2.0",
                 "wmde/email-address": "~1.0",
                 "wmde/euro": "~1.0",
                 "wmde/fun-validators": "~5.0",
                 "wmde/fundraising-payments": "~8.4"
             },
             "require-dev": {
-                "phpstan/phpstan": "~2.1.11",
+                "phpstan/phpstan": "~2.2.0",
                 "phpstan/phpstan-doctrine": "~2.0.2",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "~12.0",
                 "symfony/cache": "^8.0",
-                "wmde/clock": "^2.0",
-                "wmde/fundraising-phpcs": "~14.0",
+                "wmde/fundraising-phpcs": "~16.0",
                 "wmde/psr-log-test-doubles": "~3.0"
             },
             "bin": [
@@ -7275,7 +7275,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Bounded Context for the Wikimedia Deutschland fundraising membership subdomain",
-            "time": "2026-05-06T13:52:50+00:00"
+            "time": "2026-08-31T11:57:09+00:00"
         },
         {
             "name": "wmde/fundraising-payments",
@@ -8155,11 +8155,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.9",
+            "version": "2.2.12",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/13d6b4f347bad222da436580c8304fa6f83e6bd0",
-                "reference": "13d6b4f347bad222da436580c8304fa6f83e6bd0",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/174b0d88710f00a42598886504dd7a146f91ace5",
+                "reference": "174b0d88710f00a42598886504dd7a146f91ace5",
                 "shasum": ""
             },
             "require": {
@@ -8215,7 +8215,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-22T07:38:16+00:00"
+            "time": "2026-08-31T19:09:43+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",
@@ -10106,12 +10106,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-frontend-content",
-                "reference": "d70da5b605d6076756d181e40b3a03464255af36"
+                "reference": "475038d124ef236ba480a69cf731606567a21e47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/d70da5b605d6076756d181e40b3a03464255af36",
-                "reference": "d70da5b605d6076756d181e40b3a03464255af36",
+                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/475038d124ef236ba480a69cf731606567a21e47",
+                "reference": "475038d124ef236ba480a69cf731606567a21e47",
                 "shasum": ""
             },
             "require": {
@@ -10164,7 +10164,7 @@
                 "CC0-1.0"
             ],
             "description": "i18n for FundraisingFrontend",
-            "time": "2026-07-23T09:19:59+00:00"
+            "time": "2026-09-01T06:23:09+00:00"
         },
         {
             "name": "wmde/fundraising-phpcs",
@@ -10280,5 +10280,5 @@
     "platform-overrides": {
         "php": "8.4"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -42,6 +42,7 @@ use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mailer\Transport\NullTransport;
 use Twig\Environment;
+use WMDE\Clock\Clock;
 use WMDE\Clock\SystemClock;
 use WMDE\EmailAddress\EmailAddress;
 use WMDE\Euro\Euro;
@@ -1263,7 +1264,8 @@ class FunFunFactory implements LoggerAwareInterface {
 			$this->newMembershipTrackingRepository(),
 			$this->getMembershipEventEmitter(),
 			$this->getIncentiveFinder(),
-			$this->newPaymentServiceFactory()
+			$this->newPaymentServiceFactory(),
+			$this->getClock()
 		);
 	}
 
@@ -1377,7 +1379,7 @@ class FunFunFactory implements LoggerAwareInterface {
 			),
 			new UrlAuthenticatorStub(),
 			$this->config[ 'membership-fee-change-active' ],
-			new SystemClock()
+			$this->getClock()
 		);
 	}
 
@@ -1855,7 +1857,7 @@ class FunFunFactory implements LoggerAwareInterface {
 
 	private function getUserDataKeyGenerator(): UserDataKeyGenerator {
 		return $this->createSharedObject( UserDataKeyGenerator::class, function (): UserDataKeyGenerator {
-			return new UserDataKeyGenerator( $this->config['user-data-key'], new SystemClock() );
+			return new UserDataKeyGenerator( $this->config['user-data-key'], $this->getClock() );
 		} );
 	}
 
@@ -2200,5 +2202,16 @@ class FunFunFactory implements LoggerAwareInterface {
 			$blockList = $this->config['email-address-blacklist'] ?? [];
 		}
 		return $blockList;
+	}
+
+	private function getClock(): Clock {
+		return $this->createSharedObject( Clock::class, static function (): Clock {
+			return new SystemClock();
+		} );
+	}
+
+	public function setClock( Clock $clock ): self {
+		$this->sharedObjects[ Clock::class ] = $clock;
+		return $this;
 	}
 }

--- a/tests/EdgeToEdge/Routes/ApplyForMembershipRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ApplyForMembershipRouteTest.php
@@ -9,6 +9,7 @@ use Monolog\Logger;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
+use WMDE\Clock\StubClock;
 use WMDE\Fundraising\AddressChangeContext\Domain\Model\AddressChange;
 use WMDE\Fundraising\Frontend\App\Controllers\Membership\ApplyForMembershipController;
 use WMDE\Fundraising\Frontend\App\Controllers\Membership\ShowMembershipApplicationFormController;
@@ -37,6 +38,13 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 	private const CORRECT_ACCESS_TOKEN = '4711abc';
 
 	private const APPLY_FOR_MEMBERSHIP_ROUTE = 'apply-for-membership';
+
+	private StubClock $clock;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->clock = new StubClock( new \DateTimeImmutable() );
+	}
 
 	public function testGivenGetRequestMembership_formIsShown(): void {
 		$this->modifyConfiguration( [ 'skin' => 'laika' ] );
@@ -379,7 +387,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 	}
 
 	private function givenConfirmedMembershipApplication( int $id ): MembershipApplication {
-		$application = ValidMembershipApplication::newDomainEntity( $id );
+		$application = ValidMembershipApplication::newDomainEntity( $id, $this->clock->now() );
 		$application->confirm();
 		return $application;
 	}
@@ -419,7 +427,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 
 		$this->assertNotNull( $application );
 
-		$expectedApplication = ValidMembershipApplication::newCompanyApplication( self::MEMBERSHIP_APPLICATION_ID );
+		$expectedApplication = ValidMembershipApplication::newCompanyApplication( self::MEMBERSHIP_APPLICATION_ID, $this->clock->now() );
 		$expectedApplication->confirm();
 
 		$this->assertEquals( $expectedApplication, $application );
@@ -529,6 +537,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		$incentive = new Incentive( ValidMembershipApplication::INCENTIVE_NAME );
 		$this->insertIncentives( $factory, $incentive );
 		$factory->getConnection()->executeStatement( 'UPDATE last_generated_membership_id SET membership_id = ' . ( self::MEMBERSHIP_APPLICATION_ID - 1 ) );
+		$factory->setClock( $this->clock );
 
 		return $incentive;
 	}


### PR DESCRIPTION
This fixes the test errors introduced through the changes in  https://github.com/wmde/fundraising-memberships/pull/329 and changes the code to incorporate the backwards-breaking changes in https://github.com/wmde/fundraising-memberships/pull/336

- Add Clock dependency for `ApplyForMembershipUseCase`.
- In the `FunFunFactory` the `Clock` dependency is now a shared object.
- Update `ApplyForMembershipRouteTest` with a `StubClock` instance so the microseconds of the `createdAt` timestamp in the database match the microseconds of the fixture.
- Add additional parameters for `AnonymiseMemberCommand`. Since this is an "internal" (developer-facing) command, it's OK to hard code the grace period. I've taken the same value (2 days) as in the command for donations

This fixes the test errors introduced through the changes in  https://github.com/wmde/fundraising-memberships/pull/329 and changes the code to incorporate the backwards-breaking changes in https://github.com/wmde/fundraising-memberships/pull/336


Ticket: https://phabricator.wikimedia.org/T431116